### PR TITLE
fix(w_div): skip Expanded wrap for flex-* children inside overflow-x/y scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **Flex in Scrollable Axis**: `flex-1` / `flex-N` children inside `flex-row` + `overflow-x-auto|scroll` (or `flex-col` + `overflow-y-auto|scroll`) no longer throw "RenderFlex children have non-zero flex but incoming constraints are unbounded." The parent now signals via `WindFlexOverflowScope` so direct flex children skip `Expanded`/`Flexible` wrapping for that render pass. Responsive variants (`base:overflow-x-auto sm:overflow-visible` + `sm:flex-1`) work end-to-end. (#54)
+
 ---
 
 ## [1.0.0-alpha.6] - 2026-04-04

--- a/doc/layout/flexbox.md
+++ b/doc/layout/flexbox.md
@@ -15,6 +15,7 @@ Utilities for controlling flex containers, direction, alignment, wrapping, and s
 - [Responsive Design](#responsive-design)
 - [Arbitrary Values](#arbitrary-values)
 - [Customizing Theme](#customizing-theme)
+- [Flex Children Inside a Scrollable Axis](#flex-and-overflow)
 - [Related Documentation](#related-documentation)
 
 <x-preview path="layout/flex_intro" size="md" source="example/lib/pages/layout/flex_intro.dart"></x-preview>
@@ -269,6 +270,25 @@ WindThemeData(
   baseSpacingUnit: 8.0, // Now gap-1 = 8px, gap-2 = 16px
 )
 ```
+
+<a name="flex-and-overflow"></a>
+## Flex Children Inside a Scrollable Axis
+
+When a flex container's own main axis is scrollable (`flex-row` with `overflow-x-auto|scroll`, or `flex-col` with `overflow-y-auto|scroll`), Flutter's `Expanded`/`Flexible` cannot resolve — the incoming constraint is unbounded. Wind detects this at resolution time and skips the `Expanded`/`Flexible` wrap for direct flex children in that pass, so `flex-N` becomes a no-op while the axis is scrollable.
+
+This enables the common responsive pattern of "scroll on narrow, distribute on wide":
+
+```dart
+WDiv(
+  className: 'flex flex-row gap-1 overflow-x-auto sm:overflow-visible',
+  children: [
+    for (final tab in tabs)
+      WDiv(className: 'flex-1', child: _tabBtn(tab)),
+  ],
+)
+```
+
+At `base` the row scrolls horizontally and children keep their intrinsic width. At `sm+` the overflow is removed and `flex-1` distributes width equally. Nested non-scrolling flex subtrees under a scrolling ancestor behave normally.
 
 <a name="related-documentation"></a>
 ## Related Documentation

--- a/lib/src/state/wind_flex_overflow_scope.dart
+++ b/lib/src/state/wind_flex_overflow_scope.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/widgets.dart';
+
+/// Signals that the nearest flex ancestor has a scrollable main axis, so
+/// direct flex children must skip `Expanded`/`Flexible` wrapping (those
+/// widgets require bounded main-axis constraints and assert inside
+/// `overflow-x-auto` / `overflow-y-auto` rows/columns).
+///
+/// Every `WDiv` that builds a `Row`/`Column` installs this scope for its
+/// children, either with [skipExpanded] `true` (scrollable main axis) or
+/// `false` (resets the scope so deeper flex subtrees behave normally).
+class WindFlexOverflowScope extends InheritedWidget {
+  /// Whether direct flex children should skip `Expanded`/`Flexible`.
+  final bool skipExpanded;
+
+  const WindFlexOverflowScope({
+    super.key,
+    required this.skipExpanded,
+    required super.child,
+  });
+
+  /// Returns the nearest [WindFlexOverflowScope] without subscribing.
+  ///
+  /// Lookup is intentionally non-subscribing: the scope only needs to be
+  /// read once during build; if it changes the parent rebuild already
+  /// reaches this subtree via the child list.
+  static WindFlexOverflowScope? maybeOf(BuildContext context) {
+    return context.getInheritedWidgetOfExactType<WindFlexOverflowScope>();
+  }
+
+  @override
+  bool updateShouldNotify(WindFlexOverflowScope oldWidget) {
+    return oldWidget.skipExpanded != skipExpanded;
+  }
+}

--- a/lib/src/state/wind_flex_overflow_scope.dart
+++ b/lib/src/state/wind_flex_overflow_scope.dart
@@ -18,13 +18,11 @@ class WindFlexOverflowScope extends InheritedWidget {
     required super.child,
   });
 
-  /// Returns the nearest [WindFlexOverflowScope] without subscribing.
-  ///
-  /// Lookup is intentionally non-subscribing: the scope only needs to be
-  /// read once during build; if it changes the parent rebuild already
-  /// reaches this subtree via the child list.
+  /// Returns the nearest [WindFlexOverflowScope] and subscribes so dependents
+  /// rebuild when `skipExpanded` changes (e.g. parent toggles overflow via
+  /// `setState`).
   static WindFlexOverflowScope? maybeOf(BuildContext context) {
-    return context.getInheritedWidgetOfExactType<WindFlexOverflowScope>();
+    return context.dependOnInheritedWidgetOfExactType<WindFlexOverflowScope>();
   }
 
   @override

--- a/lib/src/widgets/w_div.dart
+++ b/lib/src/widgets/w_div.dart
@@ -5,6 +5,7 @@ import '../parser/wind_style.dart';
 import '../utils/wind_logger.dart';
 import 'wind_animation_wrapper.dart';
 import '../state/wind_anchor_state_provider.dart';
+import '../state/wind_flex_overflow_scope.dart';
 import 'w_anchor.dart';
 import 'w_text.dart';
 
@@ -187,10 +188,14 @@ class WDiv extends StatelessWidget {
     // 5. COMPOSE DECORATORS (The Decorator Layer)
     // We wrap the core structure with styling widgets (Padding, Container)
     // in a specific order (from inside out) to achieve the desired effect.
+    final bool skipFlexWrap =
+        WindFlexOverflowScope.maybeOf(context)?.skipExpanded ?? false;
+
     Widget finalWidget = _buildCompositionPipeline(
       styles: styles,
       content: coreContent,
       logger: logger,
+      skipFlexWrap: skipFlexWrap,
     );
 
     /// 6. TEXT STYLES (If applicable)
@@ -319,25 +324,37 @@ class WDiv extends StatelessWidget {
           "${isColumn ? 'Column' : 'Row'}(child: single item)",
         );
 
+        final bool singleIsMainAxisScrollable = isColumn
+            ? (styles.overflowY == WindOverflow.auto ||
+                styles.overflowY == WindOverflow.scroll)
+            : (styles.overflowX == WindOverflow.auto ||
+                styles.overflowX == WindOverflow.scroll);
+
         if (isColumn) {
-          return Column(
-            mainAxisAlignment:
-                styles.mainAxisAlignment ?? MainAxisAlignment.start,
-            crossAxisAlignment:
-                styles.crossAxisAlignment ?? CrossAxisAlignment.start,
-            mainAxisSize: effectiveMainAxisSize,
-            textBaseline: styles.textBaseline,
-            children: [child!],
+          return WindFlexOverflowScope(
+            skipExpanded: singleIsMainAxisScrollable,
+            child: Column(
+              mainAxisAlignment:
+                  styles.mainAxisAlignment ?? MainAxisAlignment.start,
+              crossAxisAlignment:
+                  styles.crossAxisAlignment ?? CrossAxisAlignment.start,
+              mainAxisSize: effectiveMainAxisSize,
+              textBaseline: styles.textBaseline,
+              children: [child!],
+            ),
           );
         } else {
-          return Row(
-            mainAxisAlignment:
-                styles.mainAxisAlignment ?? MainAxisAlignment.start,
-            crossAxisAlignment:
-                styles.crossAxisAlignment ?? CrossAxisAlignment.start,
-            mainAxisSize: effectiveMainAxisSize,
-            textBaseline: styles.textBaseline,
-            children: [child!],
+          return WindFlexOverflowScope(
+            skipExpanded: singleIsMainAxisScrollable,
+            child: Row(
+              mainAxisAlignment:
+                  styles.mainAxisAlignment ?? MainAxisAlignment.start,
+              crossAxisAlignment:
+                  styles.crossAxisAlignment ?? CrossAxisAlignment.start,
+              mainAxisSize: effectiveMainAxisSize,
+              textBaseline: styles.textBaseline,
+              children: [child!],
+            ),
           );
         }
       }
@@ -430,6 +447,17 @@ class WDiv extends StatelessWidget {
     // Check if overflow-hidden is set (requires children to shrink)
     final hasOverflowClip = styles.clipBehavior == Clip.hardEdge;
 
+    // When the flex main axis is itself scrollable (overflow-x-auto/scroll on
+    // Row, overflow-y-auto/scroll on Column), the incoming main-axis
+    // constraint is unbounded. Flex children wrapped in `Expanded`/`Flexible`
+    // would assert in that case, so we signal them via `WindFlexOverflowScope`
+    // to skip that wrapping for this render pass.
+    final bool isMainAxisScrollable = isColumn
+        ? (styles.overflowY == WindOverflow.auto ||
+            styles.overflowY == WindOverflow.scroll)
+        : (styles.overflowX == WindOverflow.auto ||
+            styles.overflowX == WindOverflow.scroll);
+
     // Inject gaps if necessary (SRP: delegated to helper)
     final gappedChildren = _buildGappedChildren(
       children: children!,
@@ -464,18 +492,24 @@ class WDiv extends StatelessWidget {
     );
 
     if (isColumn) {
-      return Column(
-        mainAxisAlignment: styles.mainAxisAlignment ?? MainAxisAlignment.start,
-        crossAxisAlignment:
-            styles.crossAxisAlignment ?? CrossAxisAlignment.start,
-        mainAxisSize: effectiveMainAxisSize,
-        textBaseline: styles.textBaseline,
-        children: gappedChildren,
+      return WindFlexOverflowScope(
+        skipExpanded: isMainAxisScrollable,
+        child: Column(
+          mainAxisAlignment:
+              styles.mainAxisAlignment ?? MainAxisAlignment.start,
+          crossAxisAlignment:
+              styles.crossAxisAlignment ?? CrossAxisAlignment.start,
+          mainAxisSize: effectiveMainAxisSize,
+          textBaseline: styles.textBaseline,
+          children: gappedChildren,
+        ),
       );
     } else {
       // For Row with space distribution OR overflow-hidden, wrap children with Flexible
-      // This mimics CSS flex-shrink: 1 default behavior
-      final needsFlexible = needsSpaceDistribution || hasOverflowClip;
+      // This mimics CSS flex-shrink: 1 default behavior. Inside a horizontally
+      // scrollable row, `Flexible` is also invalid — skip it too.
+      final needsFlexible =
+          (needsSpaceDistribution || hasOverflowClip) && !isMainAxisScrollable;
       final rowChildren = needsFlexible
           ? gappedChildren.map((child) {
               // Don't wrap SizedBox gaps or already-flex widgets with Flexible
@@ -500,13 +534,17 @@ class WDiv extends StatelessWidget {
             }).toList()
           : gappedChildren;
 
-      return Row(
-        mainAxisAlignment: styles.mainAxisAlignment ?? MainAxisAlignment.start,
-        crossAxisAlignment:
-            styles.crossAxisAlignment ?? CrossAxisAlignment.start,
-        mainAxisSize: effectiveMainAxisSize,
-        textBaseline: styles.textBaseline,
-        children: rowChildren,
+      return WindFlexOverflowScope(
+        skipExpanded: isMainAxisScrollable,
+        child: Row(
+          mainAxisAlignment:
+              styles.mainAxisAlignment ?? MainAxisAlignment.start,
+          crossAxisAlignment:
+              styles.crossAxisAlignment ?? CrossAxisAlignment.start,
+          mainAxisSize: effectiveMainAxisSize,
+          textBaseline: styles.textBaseline,
+          children: rowChildren,
+        ),
       );
     }
   }
@@ -696,6 +734,7 @@ class WDiv extends StatelessWidget {
     required WindStyle styles,
     required Widget? content,
     required WindLogger logger,
+    bool skipFlexWrap = false,
   }) {
     Widget? widgetToBuild = content;
 
@@ -1119,19 +1158,23 @@ class WDiv extends StatelessWidget {
       return widgetToBuild ?? const SizedBox.shrink();
     }
 
-    // Apply Flex/Expanded (flex-*)
-    if (styles.flex != null) {
-      logger.wrapWith("Expanded", "flex: ${styles.flex}");
-      widgetToBuild = Expanded(
-        flex: styles.flex!,
-        child: widgetToBuild ?? const SizedBox.shrink(),
-      );
-    } else if (styles.flexFit != null) {
-      logger.wrapWith("Flexible", "fit: ${styles.flexFit}");
-      widgetToBuild = Flexible(
-        fit: styles.flexFit!,
-        child: widgetToBuild ?? const SizedBox.shrink(),
-      );
+    // Apply Flex/Expanded (flex-*). Skipped when an ancestor signals that
+    // the flex main axis is scrollable — `Expanded`/`Flexible` inside an
+    // unbounded-width/height flex would assert.
+    if (!skipFlexWrap) {
+      if (styles.flex != null) {
+        logger.wrapWith("Expanded", "flex: ${styles.flex}");
+        widgetToBuild = Expanded(
+          flex: styles.flex!,
+          child: widgetToBuild ?? const SizedBox.shrink(),
+        );
+      } else if (styles.flexFit != null) {
+        logger.wrapWith("Flexible", "fit: ${styles.flexFit}");
+        widgetToBuild = Flexible(
+          fit: styles.flexFit!,
+          child: widgetToBuild ?? const SizedBox.shrink(),
+        );
+      }
     }
 
     return widgetToBuild ?? const SizedBox.shrink();

--- a/lib/src/widgets/w_div.dart
+++ b/lib/src/widgets/w_div.dart
@@ -324,11 +324,10 @@ class WDiv extends StatelessWidget {
           "${isColumn ? 'Column' : 'Row'}(child: single item)",
         );
 
-        final bool singleIsMainAxisScrollable = isColumn
-            ? (styles.overflowY == WindOverflow.auto ||
-                styles.overflowY == WindOverflow.scroll)
-            : (styles.overflowX == WindOverflow.auto ||
-                styles.overflowX == WindOverflow.scroll);
+        final bool singleIsMainAxisScrollable = _isMainAxisScrollable(
+          styles,
+          isColumn: isColumn,
+        );
 
         if (isColumn) {
           return WindFlexOverflowScope(
@@ -452,11 +451,10 @@ class WDiv extends StatelessWidget {
     // constraint is unbounded. Flex children wrapped in `Expanded`/`Flexible`
     // would assert in that case, so we signal them via `WindFlexOverflowScope`
     // to skip that wrapping for this render pass.
-    final bool isMainAxisScrollable = isColumn
-        ? (styles.overflowY == WindOverflow.auto ||
-            styles.overflowY == WindOverflow.scroll)
-        : (styles.overflowX == WindOverflow.auto ||
-            styles.overflowX == WindOverflow.scroll);
+    final bool isMainAxisScrollable = _isMainAxisScrollable(
+      styles,
+      isColumn: isColumn,
+    );
 
     // Inject gaps if necessary (SRP: delegated to helper)
     final gappedChildren = _buildGappedChildren(
@@ -547,6 +545,26 @@ class WDiv extends StatelessWidget {
         ),
       );
     }
+  }
+
+  /// Returns whether the container's main axis is scrollable.
+  ///
+  /// Covers both the per-axis fields (`overflow-x-auto` / `overflow-y-auto`)
+  /// and the single-field `overflow-auto` / `overflow-scroll` which renders
+  /// as nested scroll views (both axes scrollable).
+  static bool _isMainAxisScrollable(
+    WindStyle styles, {
+    required bool isColumn,
+  }) {
+    final bool bothAxes = styles.overflow == WindOverflow.auto ||
+        styles.overflow == WindOverflow.scroll;
+    if (bothAxes) return true;
+    if (isColumn) {
+      return styles.overflowY == WindOverflow.auto ||
+          styles.overflowY == WindOverflow.scroll;
+    }
+    return styles.overflowX == WindOverflow.auto ||
+        styles.overflowX == WindOverflow.scroll;
   }
 
   /// Checks if a className contains shrink-0 token that should preserve

--- a/lib/src/widgets/w_text.dart
+++ b/lib/src/widgets/w_text.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../parser/wind_parser.dart';
 import '../parser/wind_style.dart';
+import '../state/wind_flex_overflow_scope.dart';
 import '../utils/wind_logger.dart';
 
 /// **The Utility-First Text Component**
@@ -117,10 +118,14 @@ class WText extends StatelessWidget {
 
     // 5. DELEGATE COMPOSITION PIPELINE (SRP)
     // Wraps the text in layout widgets (Padding, Container, Expanded, etc.)
+    final bool skipFlexWrap =
+        WindFlexOverflowScope.maybeOf(context)?.skipExpanded ?? false;
+
     final Widget finalWidget = _buildCompositionPipeline(
       styles: styles,
       content: coreContent,
       logger: logger,
+      skipFlexWrap: skipFlexWrap,
     );
 
     // 6. FINALIZE
@@ -188,6 +193,7 @@ class WText extends StatelessWidget {
     required WindStyle styles,
     required Widget content,
     required WindLogger logger,
+    bool skipFlexWrap = false,
   }) {
     Widget widgetToBuild = content;
 
@@ -237,13 +243,15 @@ class WText extends StatelessWidget {
       widgetToBuild = Align(alignment: styles.alignment!, child: widgetToBuild);
     }
 
-    // Step E: Flex (Expanded/Flexible)
-    if (styles.flex != null) {
-      logger.wrapWith("Expanded", "flex: ${styles.flex}");
-      widgetToBuild = Expanded(flex: styles.flex!, child: widgetToBuild);
-    } else if (styles.flexFit != null) {
-      logger.wrapWith("Flexible", "fit: ${styles.flexFit}");
-      widgetToBuild = Flexible(fit: styles.flexFit!, child: widgetToBuild);
+    // Step E: Flex (Expanded/Flexible) — skipped inside a scrollable main axis.
+    if (!skipFlexWrap) {
+      if (styles.flex != null) {
+        logger.wrapWith("Expanded", "flex: ${styles.flex}");
+        widgetToBuild = Expanded(flex: styles.flex!, child: widgetToBuild);
+      } else if (styles.flexFit != null) {
+        logger.wrapWith("Flexible", "fit: ${styles.flexFit}");
+        widgetToBuild = Flexible(fit: styles.flexFit!, child: widgetToBuild);
+      }
     }
 
     return widgetToBuild;

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -41,6 +41,7 @@ Flutter constraint resolution differs fundamentally from CSS. Wind UI maps `clas
 | Vertical scroll | `overflow-y-auto` + `scrollPrimary: true` | Parent MUST have bounded height |
 | Bounded height for scroll | `flex-1` on the scrollable `WDiv` | Inside a Column/Flex parent |
 | Horizontal scroll | `overflow-x-auto` | Same rules |
+| Flex children inside scrollable main axis | `flex-1` on child works (Wind skips `Expanded` automatically when parent scrolls that axis) | `flex flex-row + overflow-x-auto` or `flex flex-col + overflow-y-auto` — no unbounded-constraints assertion |
 
 **WDiv Composition Rules**
 

--- a/test/widgets/w_div/overflow_test.dart
+++ b/test/widgets/w_div/overflow_test.dart
@@ -192,6 +192,104 @@ void main() {
       expect(find.byType(ClipRRect), findsOneWidget);
     });
 
+    testWidgets(
+      'flex-1 children inside overflow-x-auto row do not assert',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WindTheme(
+              data: WindThemeData(),
+              child: const WDiv(
+                className: 'flex flex-row overflow-x-auto',
+                children: [
+                  WDiv(className: 'flex-1', child: Text('a')),
+                  WDiv(className: 'flex-1', child: Text('b')),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(Expanded), findsNothing);
+        expect(find.text('a'), findsOneWidget);
+        expect(find.text('b'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'flex-1 children inside overflow-y-auto column do not assert',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WindTheme(
+              data: WindThemeData(),
+              child: const WDiv(
+                className: 'flex flex-col overflow-y-auto',
+                children: [
+                  WDiv(className: 'flex-1', child: Text('a')),
+                  WDiv(className: 'flex-1', child: Text('b')),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(Expanded), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'flex-1 in non-scrolling row still wraps with Expanded',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WindTheme(
+              data: WindThemeData(),
+              child: const WDiv(
+                className: 'flex flex-row',
+                children: [
+                  WDiv(className: 'flex-1', child: Text('a')),
+                  WDiv(className: 'flex-1', child: Text('b')),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(Expanded), findsNWidgets(2));
+      },
+    );
+
+    testWidgets(
+      'nested non-scrolling flex subtree re-enables Expanded under scroll',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WindTheme(
+              data: WindThemeData(),
+              child: const WDiv(
+                className: 'flex flex-row overflow-x-auto',
+                children: [
+                  WDiv(
+                    className: 'flex flex-row w-96',
+                    children: [
+                      WDiv(className: 'flex-1', child: Text('inner')),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(Expanded), findsOneWidget);
+      },
+    );
+
     testWidgets('no overflow class does not add ClipRect', (tester) async {
       await tester.pumpWidget(
         MaterialApp(

--- a/test/widgets/w_div/overflow_test.dart
+++ b/test/widgets/w_div/overflow_test.dart
@@ -2,7 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluttersdk_wind/fluttersdk_wind.dart';
 
+Widget wrapWithTheme(Widget child) {
+  return MaterialApp(
+    home: WindTheme(
+      data: WindThemeData(),
+      child: Scaffold(body: child),
+    ),
+  );
+}
+
 void main() {
+  setUp(() {
+    WindParser.clearCache();
+  });
+
   group('WDiv Overflow Feature Tests', () {
     testWidgets('overflow-hidden uses ClipRRect', (
       tester,
@@ -196,16 +209,13 @@ void main() {
       'flex-1 children inside overflow-x-auto row do not assert',
       (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            home: WindTheme(
-              data: WindThemeData(),
-              child: const WDiv(
-                className: 'flex flex-row overflow-x-auto',
-                children: [
-                  WDiv(className: 'flex-1', child: Text('a')),
-                  WDiv(className: 'flex-1', child: Text('b')),
-                ],
-              ),
+          wrapWithTheme(
+            const WDiv(
+              className: 'flex flex-row overflow-x-auto',
+              children: [
+                WDiv(className: 'flex-1', child: Text('a')),
+                WDiv(className: 'flex-1', child: Text('b')),
+              ],
             ),
           ),
         );
@@ -221,16 +231,13 @@ void main() {
       'flex-1 children inside overflow-y-auto column do not assert',
       (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            home: WindTheme(
-              data: WindThemeData(),
-              child: const WDiv(
-                className: 'flex flex-col overflow-y-auto',
-                children: [
-                  WDiv(className: 'flex-1', child: Text('a')),
-                  WDiv(className: 'flex-1', child: Text('b')),
-                ],
-              ),
+          wrapWithTheme(
+            const WDiv(
+              className: 'flex flex-col overflow-y-auto',
+              children: [
+                WDiv(className: 'flex-1', child: Text('a')),
+                WDiv(className: 'flex-1', child: Text('b')),
+              ],
             ),
           ),
         );
@@ -244,16 +251,13 @@ void main() {
       'flex-1 in non-scrolling row still wraps with Expanded',
       (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            home: WindTheme(
-              data: WindThemeData(),
-              child: const WDiv(
-                className: 'flex flex-row',
-                children: [
-                  WDiv(className: 'flex-1', child: Text('a')),
-                  WDiv(className: 'flex-1', child: Text('b')),
-                ],
-              ),
+          wrapWithTheme(
+            const WDiv(
+              className: 'flex flex-row',
+              children: [
+                WDiv(className: 'flex-1', child: Text('a')),
+                WDiv(className: 'flex-1', child: Text('b')),
+              ],
             ),
           ),
         );
@@ -267,26 +271,43 @@ void main() {
       'nested non-scrolling flex subtree re-enables Expanded under scroll',
       (tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            home: WindTheme(
-              data: WindThemeData(),
-              child: const WDiv(
-                className: 'flex flex-row overflow-x-auto',
-                children: [
-                  WDiv(
-                    className: 'flex flex-row w-96',
-                    children: [
-                      WDiv(className: 'flex-1', child: Text('inner')),
-                    ],
-                  ),
-                ],
-              ),
+          wrapWithTheme(
+            const WDiv(
+              className: 'flex flex-row overflow-x-auto',
+              children: [
+                WDiv(
+                  className: 'flex flex-row w-96',
+                  children: [
+                    WDiv(className: 'flex-1', child: Text('inner')),
+                  ],
+                ),
+              ],
             ),
           ),
         );
 
         expect(tester.takeException(), isNull);
         expect(find.byType(Expanded), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'flex-1 children inside overflow-auto (both axes) do not assert',
+      (tester) async {
+        await tester.pumpWidget(
+          wrapWithTheme(
+            const WDiv(
+              className: 'flex flex-row overflow-auto',
+              children: [
+                WDiv(className: 'flex-1', child: Text('a')),
+                WDiv(className: 'flex-1', child: Text('b')),
+              ],
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(Expanded), findsNothing);
       },
     );
 


### PR DESCRIPTION
## Summary

Closes #54.

A `flex-row` `WDiv` with `overflow-x-auto|scroll` containing a child whose className resolves to `flex-1`/`flex-N` throws Flutter's "incoming constraints are unbounded" assertion. Same problem symmetrically for `flex-col` + `overflow-y-auto|scroll`. This blocked the natural "scroll on narrow, distribute on wide" responsive pattern.

## Fix

Introduces `WindFlexOverflowScope`, an `InheritedWidget` installed by `WDiv` around every `Row`/`Column` it builds. The scope carries `skipExpanded: bool` derived from `styles.overflowX`/`overflowY` against the active flex direction. Direct flex children (`WDiv` and `WText`) read the scope during build and skip the `Expanded`/`Flexible` wrap for that render pass.

Because `styles.overflowX/Y` already resolves per active breakpoint, responsive variants (`overflow-x-auto sm:overflow-visible` + `sm:flex-1`) work end-to-end. Nested non-scrolling flex subtrees under a scrolling ancestor install their own scope with `skipExpanded: false` and keep `Expanded` intact.

Also: `needsFlexible` inside `_buildFlexStructure` is gated on `!isMainAxisScrollable` since wrapping in `Flexible` in an unbounded axis has the same failure mode.

## Test plan

- [x] `flutter test` (962 tests pass)
- [x] New widget tests in `test/widgets/w_div/overflow_test.dart` covering horizontal + vertical scroll, non-scrolling baseline, and nested-subtree override
- [x] `dart analyze` clean
- [x] `doc/layout/flexbox.md` gets a new section
- [x] `CHANGELOG.md` updated under `[Unreleased]`