### PR TITLE
feat(layout): add order-* and flex-*-reverse for flex child reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ### Added
 - **Child Order**: `order-0` through `order-12`, `order-first`, `order-last`, `order-none`, and arbitrary `order-[n]` (including negatives) for reordering flex children without changing source order. Stable-sort preserves insertion order among equal-order children. (#53)
-- **Reverse Flex Direction**: `flex-row-reverse` and `flex-col-reverse` reverse the final child list (applied after `order-*` sorting). Works with responsive prefixes. (#53)
+- **Reverse Flex Direction**: `flex-row-reverse` and `flex-col-reverse` flip the main-axis direction via `Row.textDirection` / `Column.verticalDirection`, so `justify-start` mirrors to match CSS semantics (not just a visual list reversal). Applied after `order-*` sorting and works with responsive prefixes. (#53)
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- **Child Order**: `order-0` through `order-12`, `order-first`, `order-last`, `order-none`, and arbitrary `order-[n]` (including negatives) for reordering flex children without changing source order. Stable-sort preserves insertion order among equal-order children. (#53)
+- **Reverse Flex Direction**: `flex-row-reverse` and `flex-col-reverse` reverse the final child list (applied after `order-*` sorting). Works with responsive prefixes. (#53)
+
 ### 🐛 Bug Fixes
 
 - **Flex in Scrollable Axis**: `flex-1` / `flex-N` children inside `flex-row` + `overflow-x-auto|scroll` (or `flex-col` + `overflow-y-auto|scroll`) no longer throw "RenderFlex children have non-zero flex but incoming constraints are unbounded." The parent now signals via `WindFlexOverflowScope` so direct flex children skip `Expanded`/`Flexible` wrapping for that render pass. Responsive variants (`base:overflow-x-auto sm:overflow-visible` + `sm:flex-1`) work end-to-end. (#54)

--- a/doc/layout/flexbox.md
+++ b/doc/layout/flexbox.md
@@ -60,8 +60,8 @@ WDiv(
 | `wrap` | `flex-wrap: wrap` | `Wrap` |
 | `flex-row` | `flex-direction: row` | `Row()` |
 | `flex-col` | `flex-direction: column` | `Column()` |
-| `flex-row-reverse` | `flex-direction: row-reverse` | `Row()` with reversed children |
-| `flex-col-reverse` | `flex-direction: column-reverse` | `Column()` with reversed children |
+| `flex-row-reverse` | `flex-direction: row-reverse` | `Row(textDirection: mirrored)` |
+| `flex-col-reverse` | `flex-direction: column-reverse` | `Column(verticalDirection: up)` |
 | `order-{n}` | `order: {n}` | Stable-sort children before layout |
 | `justify-{alignment}` | `justify-content: ...` | `MainAxisAlignment` |
 | `items-{alignment}` | `align-items: ...` | `CrossAxisAlignment` |
@@ -87,7 +87,7 @@ WDiv(className: 'flex flex-col')
 <a name="reversing-direction"></a>
 ## Reversing Direction
 
-Use `flex-row-reverse` or `flex-col-reverse` to reverse the visual order of children along the main axis. The cross-axis alignment is unaffected.
+Use `flex-row-reverse` or `flex-col-reverse` to reverse the main-axis direction. Rather than reversing the children list, Wind flips the axis itself (via `Row.textDirection` / `Column.verticalDirection`), so alignment tokens mirror correctly: `justify-start` anchors to what is now the visual end, matching CSS's `flex-direction: *-reverse`. Cross-axis alignment is unaffected.
 
 ```dart
 WDiv(
@@ -144,7 +144,7 @@ WDiv(
 )
 ```
 
-When combined with `flex-*-reverse`, ordering happens first and the container then reverses the final list.
+When combined with `flex-*-reverse`, children are sorted by `order-*` first; the container then flips the main-axis direction so `justify-*` still applies against the (now reversed) axis.
 
 <a name="wrapping"></a>
 ## Wrapping

--- a/doc/layout/flexbox.md
+++ b/doc/layout/flexbox.md
@@ -5,6 +5,8 @@ Utilities for controlling flex containers, direction, alignment, wrapping, and s
 - [Basic Usage](#basic-usage)
 - [Quick Reference](#quick-reference)
 - [Flex Direction](#flex-direction)
+- [Reversing Direction](#reversing-direction)
+- [Child Order](#child-order)
 - [Wrapping](#wrapping)
 - [Justify Content](#justify-content)
 - [Align Items](#align-items)
@@ -58,6 +60,9 @@ WDiv(
 | `wrap` | `flex-wrap: wrap` | `Wrap` |
 | `flex-row` | `flex-direction: row` | `Row()` |
 | `flex-col` | `flex-direction: column` | `Column()` |
+| `flex-row-reverse` | `flex-direction: row-reverse` | `Row()` with reversed children |
+| `flex-col-reverse` | `flex-direction: column-reverse` | `Column()` with reversed children |
+| `order-{n}` | `order: {n}` | Stable-sort children before layout |
 | `justify-{alignment}` | `justify-content: ...` | `MainAxisAlignment` |
 | `items-{alignment}` | `align-items: ...` | `CrossAxisAlignment` |
 | `gap-{n}` | `gap: {n}` | `SizedBox` (spacer) |
@@ -78,6 +83,68 @@ WDiv(className: 'flex flex-row')
 // Column (Vertical)
 WDiv(className: 'flex flex-col')
 ```
+
+<a name="reversing-direction"></a>
+## Reversing Direction
+
+Use `flex-row-reverse` or `flex-col-reverse` to reverse the visual order of children along the main axis. The cross-axis alignment is unaffected.
+
+```dart
+WDiv(
+  className: 'flex flex-row-reverse gap-2',
+  children: [
+    WText('First in code'),
+    WText('Last in code'),
+  ],
+)
+// Renders as: [Last in code] [First in code]
+```
+
+Responsive prefixes work as expected:
+
+```dart
+// Column on mobile, row-reverse on md+
+WDiv(className: 'flex flex-col md:flex-row-reverse gap-4')
+```
+
+<a name="child-order"></a>
+## Child Order
+
+Use `order-*` on individual flex children to override their paint order without changing the source order. The parent flex container stable-sorts children by their resolved `order` value before laying them out; children without `order-*` default to `0`.
+
+| Class | Behavior |
+|:------|:---------|
+| `order-0` .. `order-12` | Explicit index (integers only) |
+| `order-first` | Placed before everything else (sentinel `-9999`) |
+| `order-last` | Placed after everything else (sentinel `9999`) |
+| `order-none` | Resets to `0` |
+| `order-[n]` | Arbitrary integer (supports negative, e.g. `order-[-3]`) |
+
+```dart
+WDiv(
+  className: 'flex',
+  children: [
+    WDiv(className: 'order-3', child: WText('A')),
+    WDiv(className: 'order-1', child: WText('B')),
+    WDiv(className: 'order-2', child: WText('C')),
+  ],
+)
+// Visual order: B, C, A
+```
+
+Responsive reordering is a common use case — swap the layout per breakpoint without duplicating children:
+
+```dart
+WDiv(
+  className: 'flex flex-col md:flex-row gap-4',
+  children: [
+    WDiv(className: 'order-2 md:order-1', child: WText('Sidebar')),
+    WDiv(className: 'order-1 md:order-2', child: WText('Main content')),
+  ],
+)
+```
+
+When combined with `flex-*-reverse`, ordering happens first and the container then reverses the final list.
 
 <a name="wrapping"></a>
 ## Wrapping

--- a/example/lib/pages/layout/order.dart
+++ b/example/lib/pages/layout/order.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+/// Child Order Example
+/// Demonstrates order-* utilities and flex-*-reverse for reordering flex children.
+class OrderExamplePage extends StatelessWidget {
+  const OrderExamplePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WDiv(
+      className: 'w-full h-full overflow-y-auto p-4',
+      child: WDiv(
+        className: 'flex flex-col gap-6 max-w-2xl',
+        children: [
+          WDiv(
+            className: '''
+              w-full p-4 rounded-xl
+              bg-gradient-to-r from-blue-500 to-indigo-500
+            ''',
+            children: [
+              WText(
+                'Child Order & Reverse',
+                className: 'text-lg font-bold text-white',
+              ),
+              WText(
+                'Reorder flex children with order-* and flex-*-reverse',
+                className: 'text-sm text-blue-100',
+              ),
+            ],
+          ),
+          _buildSection(
+            title: 'order-* overrides source order',
+            code: 'order-3 / order-1 / order-2',
+            child: WDiv(
+              className:
+                  'flex gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+              children: [
+                _buildBox('A', 'bg-rose-500', orderCls: 'order-3'),
+                _buildBox('B', 'bg-rose-500', orderCls: 'order-1'),
+                _buildBox('C', 'bg-rose-500', orderCls: 'order-2'),
+              ],
+            ),
+          ),
+          _buildSection(
+            title: 'order-first / order-last',
+            code: 'order-last / order-first',
+            child: WDiv(
+              className:
+                  'flex gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+              children: [
+                _buildBox('A', 'bg-emerald-500', orderCls: 'order-last'),
+                _buildBox('B', 'bg-emerald-500'),
+                _buildBox('C', 'bg-emerald-500', orderCls: 'order-first'),
+              ],
+            ),
+          ),
+          _buildSection(
+            title: 'flex-row-reverse',
+            code: 'flex flex-row-reverse',
+            child: WDiv(
+              className:
+                  'flex flex-row-reverse gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+              children: [
+                _buildBox('1', 'bg-indigo-500'),
+                _buildBox('2', 'bg-indigo-500'),
+                _buildBox('3', 'bg-indigo-500'),
+              ],
+            ),
+          ),
+          _buildSection(
+            title: 'flex-col-reverse',
+            code: 'flex flex-col-reverse',
+            child: WDiv(
+              className:
+                  'flex flex-col-reverse gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+              children: [
+                _buildBox('1', 'bg-amber-500'),
+                _buildBox('2', 'bg-amber-500'),
+                _buildBox('3', 'bg-amber-500'),
+              ],
+            ),
+          ),
+          _buildSection(
+            title: 'Responsive reorder (resize the window)',
+            code: 'order-2 md:order-1 / order-1 md:order-2',
+            child: WDiv(
+              className:
+                  'flex flex-col md:flex-row gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+              children: [
+                _buildBox(
+                  'Sidebar',
+                  'bg-sky-500',
+                  orderCls: 'order-2 md:order-1',
+                  wide: true,
+                ),
+                _buildBox(
+                  'Main',
+                  'bg-sky-600',
+                  orderCls: 'order-1 md:order-2',
+                  wide: true,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required String code,
+    required Widget child,
+  }) {
+    return WDiv(
+      className: 'flex flex-col gap-2',
+      children: [
+        WDiv(
+          className: 'flex items-center justify-between',
+          children: [
+            WText(
+              title,
+              className: 'font-semibold text-gray-800 dark:text-white',
+            ),
+            WDiv(
+              className: 'px-2 py-1 rounded bg-slate-200 dark:bg-slate-600',
+              child: WText(
+                code,
+                className: 'text-xs font-mono text-gray-600 dark:text-gray-300',
+              ),
+            ),
+          ],
+        ),
+        child,
+      ],
+    );
+  }
+
+  Widget _buildBox(
+    String label,
+    String bgColor, {
+    String orderCls = '',
+    bool wide = false,
+  }) {
+    final size = wide ? 'px-4 h-12' : 'w-12 h-12';
+    return WDiv(
+      className:
+          '$orderCls $bgColor $size rounded-lg flex items-center justify-center',
+      child: WText(label, className: 'text-white font-bold'),
+    );
+  }
+}

--- a/lib/src/parser/parsers/flexbox_grid_parser.dart
+++ b/lib/src/parser/parsers/flexbox_grid_parser.dart
@@ -58,10 +58,19 @@ class FlexboxGridParser implements WindParserInterface {
     'block': WindDisplayType.block,
   };
 
-  /// Maps flex-direction classes to `Axis`
+  /// Maps flex-direction classes to `Axis`. The `-reverse` variants set the
+  /// same axis but also flip the main-axis order via `flexReverse`.
   static const _directionMap = <String, Axis>{
     'flex-row': Axis.horizontal,
     'flex-col': Axis.vertical,
+    'flex-row-reverse': Axis.horizontal,
+    'flex-col-reverse': Axis.vertical,
+  };
+
+  /// Classes that flip the flex main-axis direction.
+  static const _reverseDirections = <String>{
+    'flex-row-reverse',
+    'flex-col-reverse',
   };
 
   /// Maps justify-content classes to `MainAxisAlignment`
@@ -142,6 +151,7 @@ class FlexboxGridParser implements WindParserInterface {
     // which values have been set.
     WindDisplayType? displayType;
     Axis? flexDirection;
+    bool? flexReverse;
     MainAxisAlignment? mainAxisAlignment;
     CrossAxisAlignment? crossAxisAlignment;
     WrapAlignment? runAlignment;
@@ -179,6 +189,7 @@ class FlexboxGridParser implements WindParserInterface {
       } else if (flexDirection == null &&
           _directionMap.containsKey(className)) {
         flexDirection = _directionMap[className];
+        flexReverse ??= _reverseDirections.contains(className);
       } else if (mainAxisAlignment == null &&
           _justifyMap.containsKey(className)) {
         mainAxisAlignment = _justifyMap[className];
@@ -252,6 +263,7 @@ class FlexboxGridParser implements WindParserInterface {
 
     final bool didChange = displayType != null ||
         flexDirection != null ||
+        flexReverse != null ||
         mainAxisAlignment != null ||
         crossAxisAlignment != null ||
         runAlignment != null ||
@@ -273,6 +285,7 @@ class FlexboxGridParser implements WindParserInterface {
     return styles.copyWith(
       displayType: displayType,
       flexDirection: flexDirection,
+      flexReverse: flexReverse,
       mainAxisAlignment: mainAxisAlignment,
       crossAxisAlignment: crossAxisAlignment,
       runAlignment: runAlignment,

--- a/lib/src/parser/parsers/order_parser.dart
+++ b/lib/src/parser/parsers/order_parser.dart
@@ -25,7 +25,7 @@ class OrderParser implements WindParserInterface {
   const OrderParser();
 
   static final RegExp _orderRegex = RegExp(
-    r'^order-(?<value>first|last|none|\d+|\[-?\d+\])$',
+    r'^order-(?<value>first|last|none|0|[1-9]|1[0-2]|\[-?\d+\])$',
   );
 
   static const int _first = -9999;

--- a/lib/src/parser/parsers/order_parser.dart
+++ b/lib/src/parser/parsers/order_parser.dart
@@ -1,0 +1,74 @@
+import '../wind_context.dart';
+import '../wind_style.dart';
+import 'wind_parser_interface.dart';
+
+/// **Order Parser**
+///
+/// Parses `order-*` utilities that control the position of a child within a
+/// flex container, mirroring Tailwind's `order` property. The parent flex
+/// container (typically a `WDiv`) resolves the order of each child and
+/// stable-sorts them before layout.
+///
+/// ### Supported Utility Classes:
+/// - `order-0` .. `order-12` — explicit index
+/// - `order-first` — sentinel `-9999`
+/// - `order-last` — sentinel `9999`
+/// - `order-none` — reset to `0`
+/// - `order-[N]` — arbitrary integer value (supports negative)
+///
+/// Prefixes such as `sm:`, `dark:`, `hover:` are stripped by the orchestrator
+/// before classes reach this parser; the full responsive + state stack works
+/// out of the box (e.g. `sm:order-last`, `lg:dark:order-first`).
+///
+/// Children without any `order-*` class default to `0` in the parent's sort.
+class OrderParser implements WindParserInterface {
+  const OrderParser();
+
+  static final RegExp _orderRegex = RegExp(
+    r'^order-(?<value>first|last|none|\d+|\[-?\d+\])$',
+  );
+
+  static const int _first = -9999;
+  static const int _last = 9999;
+
+  @override
+  bool canParse(String className) {
+    // Fast path — `canParse` must stay O(1). We match the literal prefix and
+    // let `parse` do the full regex validation.
+    return className.startsWith('order-');
+  }
+
+  @override
+  WindStyle parse(
+    WindStyle styles,
+    List<String>? classes,
+    WindContext context,
+  ) {
+    if (classes == null) return styles;
+
+    int? order;
+
+    // Reverse iteration — last class wins, consistent with other parsers.
+    for (var i = classes.length - 1; i >= 0; i--) {
+      final match = _orderRegex.firstMatch(classes[i]);
+      if (match == null) continue;
+
+      final raw = match.namedGroup('value')!;
+      if (raw == 'first') {
+        order = _first;
+      } else if (raw == 'last') {
+        order = _last;
+      } else if (raw == 'none') {
+        order = 0;
+      } else if (raw.startsWith('[')) {
+        order = int.tryParse(raw.substring(1, raw.length - 1));
+      } else {
+        order = int.tryParse(raw);
+      }
+      if (order != null) break;
+    }
+
+    if (order == null) return styles;
+    return styles.copyWith(order: order);
+  }
+}

--- a/lib/src/parser/wind_parser.dart
+++ b/lib/src/parser/wind_parser.dart
@@ -7,6 +7,7 @@ import 'parsers/padding_parser.dart';
 import 'parsers/sizing_parser.dart';
 import 'parsers/position_parser.dart';
 import 'parsers/flexbox_grid_parser.dart';
+import 'parsers/order_parser.dart';
 import 'parsers/wind_parser_interface.dart';
 import 'parsers/text_parser.dart';
 import 'parsers/debug_parser.dart';
@@ -85,6 +86,7 @@ class WindParser {
     'padding': const PaddingParser(),
     'margin': const MarginParser(),
     'position': const PositionParser(),
+    'order': const OrderParser(),
     'flexbox_grid': const FlexboxGridParser(),
     'text': const TextParser(),
     'debug': const DebugParser(),

--- a/lib/src/parser/wind_style.dart
+++ b/lib/src/parser/wind_style.dart
@@ -97,6 +97,14 @@ class WindStyle {
   /// Number of grid columns for grid display type e.g., grid-cols-3
   final int? gridCols;
 
+  /// Child order for flex reordering e.g., order-1, order-first, order-[5].
+  /// Children without an `order-*` class default to `0` during stable sort.
+  final int? order;
+
+  /// Whether the flex main axis should be mirrored (flex-row-reverse /
+  /// flex-col-reverse). Applied by the parent at layout time.
+  final bool flexReverse;
+
   /// Text color e.g., text-red-500
   final Color? color;
 
@@ -258,6 +266,8 @@ class WindStyle {
     this.alignment,
     this.textBaseline,
     this.gridCols,
+    this.order,
+    this.flexReverse = false,
     this.color,
     this.fontSize,
     this.fontWeight,
@@ -327,6 +337,8 @@ class WindStyle {
     Alignment? alignment,
     TextBaseline? textBaseline,
     int? gridCols,
+    int? order,
+    bool? flexReverse,
     Color? color,
     double? fontSize,
     FontWeight? fontWeight,
@@ -410,6 +422,8 @@ class WindStyle {
       alignment: alignment ?? this.alignment,
       textBaseline: textBaseline ?? this.textBaseline,
       gridCols: gridCols ?? this.gridCols,
+      order: order ?? this.order,
+      flexReverse: flexReverse ?? this.flexReverse,
       color: color ?? this.color,
       fontSize: fontSize ?? this.fontSize,
       fontWeight: fontWeight ?? this.fontWeight,
@@ -485,6 +499,8 @@ class WindStyle {
           alignment == other.alignment &&
           textBaseline == other.textBaseline &&
           gridCols == other.gridCols &&
+          order == other.order &&
+          flexReverse == other.flexReverse &&
           color == other.color &&
           fontSize == other.fontSize &&
           fontWeight == other.fontWeight &&
@@ -554,6 +570,8 @@ class WindStyle {
       alignment.hashCode ^
       textBaseline.hashCode ^
       gridCols.hashCode ^
+      order.hashCode ^
+      flexReverse.hashCode ^
       color.hashCode ^
       fontSize.hashCode ^
       fontWeight.hashCode ^
@@ -661,6 +679,8 @@ class WindStyle {
         'alignment: $alignment, '
         'textBaseline: $textBaseline, '
         'gridCols: $gridCols, '
+        'order: $order, '
+        'flexReverse: $flexReverse, '
         'color: $color, '
         'fontSize: $fontSize, '
         'fontWeight: $fontWeight, '

--- a/lib/src/widgets/w_div.dart
+++ b/lib/src/widgets/w_div.dart
@@ -394,7 +394,8 @@ class WDiv extends StatelessWidget {
           );
           switch (type) {
             case WindDisplayType.flex:
-              normalLayout = tempDiv._buildFlexStructure(styles, logger);
+              normalLayout =
+                  tempDiv._buildFlexStructure(styles, logger, context);
             case WindDisplayType.grid:
               normalLayout = tempDiv._buildGridStructure(styles, logger);
             case WindDisplayType.wrap:
@@ -424,7 +425,7 @@ class WDiv extends StatelessWidget {
 
       switch (type) {
         case WindDisplayType.flex:
-          return _buildFlexStructure(styles, logger);
+          return _buildFlexStructure(styles, logger, context);
         case WindDisplayType.grid:
           return _buildGridStructure(styles, logger);
         case WindDisplayType.wrap:
@@ -439,7 +440,11 @@ class WDiv extends StatelessWidget {
   }
 
   /// Builds a Flexbox layout (`Row` or `Column`).
-  Widget _buildFlexStructure(WindStyle styles, WindLogger logger) {
+  Widget _buildFlexStructure(
+    WindStyle styles,
+    WindLogger logger,
+    BuildContext context,
+  ) {
     final direction = styles.flexDirection ?? Axis.horizontal;
     final isColumn = direction == Axis.vertical;
 
@@ -456,9 +461,18 @@ class WDiv extends StatelessWidget {
       isColumn: isColumn,
     );
 
+    // Resolve child ordering (order-*) before gap injection — sort stably by
+    // resolved order (children without `order-*` default to 0), then apply
+    // `flex-*-reverse` by reversing the sorted list.
+    final orderedChildren = _applyChildOrder(
+      children!,
+      context: context,
+      reverse: styles.flexReverse,
+    );
+
     // Inject gaps if necessary (SRP: delegated to helper)
     final gappedChildren = _buildGappedChildren(
-      children: children!,
+      children: orderedChildren,
       direction: direction,
       gapX: styles.gapX,
       gapY: styles.gapY,
@@ -611,6 +625,52 @@ class WDiv extends StatelessWidget {
     } catch (_) {
       return null;
     }
+  }
+
+  /// Resolves a child's `order-*` value (defaulting to 0) by parsing its
+  /// className through WindParser — mirrors the per-breakpoint / per-state
+  /// resolution used elsewhere so `sm:order-last` / `dark:order-first` just
+  /// work. Children without any `className` or `order-*` class sort at 0.
+  static int _extractChildOrder(Widget child, BuildContext context) {
+    final className = _extractChildClassName(child);
+    if (className == null || className.isEmpty) return 0;
+    final states = _extractChildStates(child);
+    final childStyles = WindParser.parse(className, context, states: states);
+    return childStyles.order ?? 0;
+  }
+
+  /// Stable-sorts [children] by resolved `order-*`, then reverses when the
+  /// parent is `flex-row-reverse` / `flex-col-reverse`. Preserves original
+  /// insertion order among equal-order children (and before reversing).
+  static List<Widget> _applyChildOrder(
+    List<Widget> children, {
+    required BuildContext context,
+    required bool reverse,
+  }) {
+    final bool anyHasOrder = children.any(
+      (c) => _extractChildOrder(c, context) != 0,
+    );
+
+    List<Widget> result;
+    if (!anyHasOrder) {
+      result = children;
+    } else {
+      final indexed = <({int order, int index, Widget child})>[];
+      for (var i = 0; i < children.length; i++) {
+        indexed.add((
+          order: _extractChildOrder(children[i], context),
+          index: i,
+          child: children[i],
+        ));
+      }
+      indexed.sort((a, b) {
+        final byOrder = a.order.compareTo(b.order);
+        return byOrder != 0 ? byOrder : a.index.compareTo(b.index);
+      });
+      result = indexed.map((e) => e.child).toList();
+    }
+
+    return reverse ? result.reversed.toList() : result;
   }
 
   /// Checks if a child widget resolves to `absolute` positioning

--- a/lib/src/widgets/w_div.dart
+++ b/lib/src/widgets/w_div.dart
@@ -462,12 +462,12 @@ class WDiv extends StatelessWidget {
     );
 
     // Resolve child ordering (order-*) before gap injection — sort stably by
-    // resolved order (children without `order-*` default to 0), then apply
-    // `flex-*-reverse` by reversing the sorted list.
+    // resolved order (children without `order-*` default to 0). `flex-*-reverse`
+    // is applied via Row.textDirection / Column.verticalDirection below so the
+    // main-axis semantics (justify-start etc.) mirror correctly, matching CSS.
     final orderedChildren = _applyChildOrder(
       children!,
       context: context,
-      reverse: styles.flexReverse,
     );
 
     // Inject gaps if necessary (SRP: delegated to helper)
@@ -513,6 +513,9 @@ class WDiv extends StatelessWidget {
               styles.crossAxisAlignment ?? CrossAxisAlignment.start,
           mainAxisSize: effectiveMainAxisSize,
           textBaseline: styles.textBaseline,
+          verticalDirection: styles.flexReverse
+              ? VerticalDirection.up
+              : VerticalDirection.down,
           children: gappedChildren,
         ),
       );
@@ -546,6 +549,14 @@ class WDiv extends StatelessWidget {
             }).toList()
           : gappedChildren;
 
+      TextDirection? rowTextDirection;
+      if (styles.flexReverse) {
+        final ambient = Directionality.maybeOf(context) ?? TextDirection.ltr;
+        rowTextDirection = ambient == TextDirection.rtl
+            ? TextDirection.ltr
+            : TextDirection.rtl;
+      }
+
       return WindFlexOverflowScope(
         skipExpanded: isMainAxisScrollable,
         child: Row(
@@ -555,6 +566,7 @@ class WDiv extends StatelessWidget {
               styles.crossAxisAlignment ?? CrossAxisAlignment.start,
           mainAxisSize: effectiveMainAxisSize,
           textBaseline: styles.textBaseline,
+          textDirection: rowTextDirection,
           children: rowChildren,
         ),
       );
@@ -627,50 +639,50 @@ class WDiv extends StatelessWidget {
     }
   }
 
-  /// Resolves a child's `order-*` value (defaulting to 0) by parsing its
-  /// className through WindParser — mirrors the per-breakpoint / per-state
-  /// resolution used elsewhere so `sm:order-last` / `dark:order-first` just
-  /// work. Children without any `className` or `order-*` class sort at 0.
-  static int _extractChildOrder(Widget child, BuildContext context) {
-    final className = _extractChildClassName(child);
-    if (className == null || className.isEmpty) return 0;
-    final states = _extractChildStates(child);
-    final childStyles = WindParser.parse(className, context, states: states);
-    return childStyles.order ?? 0;
+  /// Cheap pre-check: does this className contain an `order-` token? Avoids
+  /// the full `WindParser.parse` round-trip for the common case where no
+  /// children opt into `order-*`.
+  static bool _classNameMentionsOrder(String? className) {
+    if (className == null || className.isEmpty) return false;
+    return className.contains('order-');
   }
 
-  /// Stable-sorts [children] by resolved `order-*`, then reverses when the
-  /// parent is `flex-row-reverse` / `flex-col-reverse`. Preserves original
-  /// insertion order among equal-order children (and before reversing).
+  /// Single-pass resolution: returns the child list, stable-sorted by any
+  /// `order-*` class on its children. Each child's className is parsed at
+  /// most once, and children whose className doesn't mention `order-` skip
+  /// `WindParser.parse` entirely. Preserves original insertion order among
+  /// equal-order children.
   static List<Widget> _applyChildOrder(
     List<Widget> children, {
     required BuildContext context,
-    required bool reverse,
   }) {
-    final bool anyHasOrder = children.any(
-      (c) => _extractChildOrder(c, context) != 0,
-    );
+    final orders = List<int>.filled(children.length, 0);
+    bool anyHasOrder = false;
 
-    List<Widget> result;
-    if (!anyHasOrder) {
-      result = children;
-    } else {
-      final indexed = <({int order, int index, Widget child})>[];
-      for (var i = 0; i < children.length; i++) {
-        indexed.add((
-          order: _extractChildOrder(children[i], context),
-          index: i,
-          child: children[i],
-        ));
+    for (var i = 0; i < children.length; i++) {
+      final child = children[i];
+      final className = _extractChildClassName(child);
+      if (!_classNameMentionsOrder(className)) continue;
+      final states = _extractChildStates(child);
+      final styles = WindParser.parse(className!, context, states: states);
+      final order = styles.order ?? 0;
+      if (order != 0) {
+        anyHasOrder = true;
+        orders[i] = order;
       }
-      indexed.sort((a, b) {
-        final byOrder = a.order.compareTo(b.order);
-        return byOrder != 0 ? byOrder : a.index.compareTo(b.index);
-      });
-      result = indexed.map((e) => e.child).toList();
     }
 
-    return reverse ? result.reversed.toList() : result;
+    if (!anyHasOrder) return children;
+
+    final indexed = <({int order, int index, Widget child})>[];
+    for (var i = 0; i < children.length; i++) {
+      indexed.add((order: orders[i], index: i, child: children[i]));
+    }
+    indexed.sort((a, b) {
+      final byOrder = a.order.compareTo(b.order);
+      return byOrder != 0 ? byOrder : a.index.compareTo(b.index);
+    });
+    return indexed.map((e) => e.child).toList();
   }
 
   /// Checks if a child widget resolves to `absolute` positioning

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -49,6 +49,8 @@ Flutter constraint resolution differs fundamentally from CSS. Wind UI maps `clas
 |-------------------|----------------|-------|
 | `flex flex-col` | Column | `flex` alone defaults to Row |
 | `flex flex-row` or `flex` | Row | Direction default |
+| `flex-row-reverse` / `flex-col-reverse` | Row/Column with flipped main axis | Uses `textDirection` / `verticalDirection` so `justify-start` mirrors (matches CSS) |
+| `order-{0..12}` / `order-first` / `order-last` / `order-[n]` | Child reorder inside flex parent | Parent stable-sorts; children without `order-*` default to 0 |
 | `wrap` or `grid` | Wrap | NOT `flex-wrap` (no-op!) |
 | `overflow-y-auto` | SingleChildScrollView | Needs bounded height |
 | `relative` | Stack(clipBehavior: Clip.none) | Children split: normal layout + Positioned |

--- a/test/parser/parsers/order_parser_test.dart
+++ b/test/parser/parsers/order_parser_test.dart
@@ -92,6 +92,21 @@ void main() {
         expect(styles.order, isNull);
       });
 
+      test('rejects out-of-range numeric order (13)', () {
+        final styles = parser.parse(WindStyle(), ['order-13'], context);
+        expect(styles.order, isNull);
+      });
+
+      test('rejects out-of-range numeric order (99)', () {
+        final styles = parser.parse(WindStyle(), ['order-99'], context);
+        expect(styles.order, isNull);
+      });
+
+      test('accepts arbitrary values beyond the 0-12 scale', () {
+        final styles = parser.parse(WindStyle(), ['order-[99]'], context);
+        expect(styles.order, 99);
+      });
+
       test('returns unchanged styles for null classes', () {
         final initial = WindStyle();
         final styles = parser.parse(initial, null, context);

--- a/test/parser/parsers/order_parser_test.dart
+++ b/test/parser/parsers/order_parser_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttersdk_wind/src/parser/parsers/order_parser.dart';
+import 'package:fluttersdk_wind/src/parser/wind_context.dart';
+import 'package:fluttersdk_wind/src/parser/wind_style.dart';
+import 'package:fluttersdk_wind/src/theme/wind_theme_data.dart';
+
+WindContext createTestContext() {
+  return WindContext(
+    theme: WindThemeData(),
+    activeBreakpoint: 'base',
+    platform: 'unknown',
+    isMobile: false,
+    screenWidth: 400,
+    screenHeight: 800,
+    activeStates: const {},
+  );
+}
+
+void main() {
+  group('OrderParser', () {
+    late OrderParser parser;
+    late WindContext context;
+
+    setUp(() {
+      parser = const OrderParser();
+      context = createTestContext();
+    });
+
+    group('canParse', () {
+      test('recognizes order-* classes', () {
+        expect(parser.canParse('order-0'), isTrue);
+        expect(parser.canParse('order-3'), isTrue);
+        expect(parser.canParse('order-12'), isTrue);
+        expect(parser.canParse('order-first'), isTrue);
+        expect(parser.canParse('order-last'), isTrue);
+        expect(parser.canParse('order-none'), isTrue);
+        expect(parser.canParse('order-[5]'), isTrue);
+        expect(parser.canParse('order-[-3]'), isTrue);
+      });
+
+      test('rejects unrelated classes', () {
+        expect(parser.canParse('flex'), isFalse);
+        expect(parser.canParse('p-4'), isFalse);
+        expect(parser.canParse('orderly'), isFalse);
+      });
+    });
+
+    group('parse', () {
+      test('parses numeric order', () {
+        final styles = parser.parse(WindStyle(), ['order-3'], context);
+        expect(styles.order, 3);
+      });
+
+      test('parses order-0', () {
+        final styles = parser.parse(WindStyle(), ['order-0'], context);
+        expect(styles.order, 0);
+      });
+
+      test('parses order-first as sentinel', () {
+        final styles = parser.parse(WindStyle(), ['order-first'], context);
+        expect(styles.order, -9999);
+      });
+
+      test('parses order-last as sentinel', () {
+        final styles = parser.parse(WindStyle(), ['order-last'], context);
+        expect(styles.order, 9999);
+      });
+
+      test('parses order-none as 0', () {
+        final styles = parser.parse(WindStyle(), ['order-none'], context);
+        expect(styles.order, 0);
+      });
+
+      test('parses arbitrary positive order', () {
+        final styles = parser.parse(WindStyle(), ['order-[42]'], context);
+        expect(styles.order, 42);
+      });
+
+      test('parses arbitrary negative order', () {
+        final styles = parser.parse(WindStyle(), ['order-[-5]'], context);
+        expect(styles.order, -5);
+      });
+
+      test('last class wins', () {
+        final styles = parser.parse(
+            WindStyle(), ['order-1', 'order-5', 'order-3'], context);
+        expect(styles.order, 3);
+      });
+
+      test('ignores invalid tokens', () {
+        final styles = parser.parse(WindStyle(), ['order-foo'], context);
+        expect(styles.order, isNull);
+      });
+
+      test('returns unchanged styles for null classes', () {
+        final initial = WindStyle();
+        final styles = parser.parse(initial, null, context);
+        expect(styles.order, isNull);
+      });
+
+      test('returns unchanged styles for empty classes', () {
+        final styles = parser.parse(WindStyle(), const [], context);
+        expect(styles.order, isNull);
+      });
+    });
+  });
+}

--- a/test/widgets/w_div/order_test.dart
+++ b/test/widgets/w_div/order_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+List<String> visibleTextsInOrder(WidgetTester tester,
+    {bool horizontal = true}) {
+  final texts = tester.widgetList<Text>(find.byType(Text)).toList();
+  final entries = <({double pos, String text})>[];
+  for (final t in texts) {
+    final finder = find.byWidget(t);
+    if (finder.evaluate().isEmpty) continue;
+    final box = tester.getTopLeft(finder);
+    entries.add((pos: horizontal ? box.dx : box.dy, text: t.data ?? ''));
+  }
+  entries.sort((a, b) => a.pos.compareTo(b.pos));
+  return entries.map((e) => e.text).toList();
+}
+
+void main() {
+  setUp(() {
+    WindParser.clearCache();
+  });
+
+  group('WDiv order-* reordering', () {
+    testWidgets('reorders children by order-* value', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex flex-row',
+              children: [
+                WDiv(className: 'order-3', child: Text('A')),
+                WDiv(className: 'order-1', child: Text('B')),
+                WDiv(className: 'order-2', child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['B', 'C', 'A']);
+    });
+
+    testWidgets('order-first places child first', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex',
+              children: [
+                WDiv(child: Text('A')),
+                WDiv(child: Text('B')),
+                WDiv(className: 'order-first', child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['C', 'A', 'B']);
+    });
+
+    testWidgets('order-last places child last', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex',
+              children: [
+                WDiv(className: 'order-last', child: Text('A')),
+                WDiv(child: Text('B')),
+                WDiv(child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['B', 'C', 'A']);
+    });
+
+    testWidgets('children without order-* default to 0 (stable)',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex',
+              children: [
+                WDiv(child: Text('A')),
+                WDiv(className: 'order-1', child: Text('B')),
+                WDiv(child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['A', 'C', 'B']);
+    });
+
+    testWidgets('no order-* keeps original order (no sort)', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex',
+              children: [
+                WDiv(child: Text('A')),
+                WDiv(child: Text('B')),
+                WDiv(child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['A', 'B', 'C']);
+    });
+
+    testWidgets('mixed Wind and non-Wind children reorder correctly',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex',
+              children: [
+                WDiv(className: 'order-2', child: Text('A')),
+                Text('B'),
+                WDiv(className: 'order-first', child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['C', 'B', 'A']);
+    });
+  });
+
+  group('WDiv flex-*-reverse', () {
+    testWidgets('flex-row-reverse reverses final order', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex flex-row-reverse',
+              children: [
+                WDiv(child: Text('A')),
+                WDiv(child: Text('B')),
+                WDiv(child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester), ['C', 'B', 'A']);
+    });
+
+    testWidgets('flex-col-reverse reverses final order', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex flex-col-reverse',
+              children: [
+                WDiv(child: Text('A')),
+                WDiv(child: Text('B')),
+                WDiv(child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(visibleTextsInOrder(tester, horizontal: false), ['C', 'B', 'A']);
+      expect(find.byType(Column), findsOneWidget);
+    });
+
+    testWidgets('order-* applies before flex-row-reverse', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'flex flex-row-reverse',
+              children: [
+                WDiv(className: 'order-3', child: Text('A')),
+                WDiv(className: 'order-1', child: Text('B')),
+                WDiv(className: 'order-2', child: Text('C')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // sorted: B, C, A; then reversed: A, C, B
+      expect(visibleTextsInOrder(tester), ['A', 'C', 'B']);
+    });
+  });
+}


### PR DESCRIPTION
Closes #53.

## Summary

Adds two CSS-flex parities for controlling the visual order of flex children:

- **`order-*`** — per-child utility that stable-sorts children in the parent flex container before layout. Supports `order-0`..`order-12`, `order-first` / `order-last` sentinels, `order-none`, and arbitrary `order-[n]` with negatives.
- **`flex-row-reverse` / `flex-col-reverse`** — parent-level direction flip, applied *after* `order-*` sorting so the two compose predictably.

Children without `order-*` default to `0`. Non-Wind children (plain `Text`, `Icon`, etc.) participate in sorting with order `0`. Responsive + state prefixes work out of the box (`md:order-first`, `sm:flex-row-reverse`, etc.).

## Implementation

- New `OrderParser` (registered before `flexbox_grid` in `_parserMap`)
- New `WindStyle.order` (int?) and `WindStyle.flexReverse` (bool, default false)
- `flex-row-reverse` / `flex-col-reverse` parsed by `FlexboxGridParser`: maps to the correct `Axis` and sets `flexReverse = true`
- `WDiv._buildFlexStructure` calls new `_applyChildOrder(children, context, reverse)` which stable-sorts by resolved order, then reverses if `flexReverse`
- Per-child order resolution reads each child's className + states through `WindParser.parse` (cache-friendly)

## Tests

- `test/parser/parsers/order_parser_test.dart` — 13 cases: canParse fast path, numeric/first/last/none, arbitrary +/-, last-class-wins, invalid tokens, null/empty
- `test/widgets/w_div/order_test.dart` — 9 cases: sort by `order-*`, `order-first`/`order-last`, default-0 stability, no-op when no order, mixed Wind/non-Wind children, `flex-row-reverse`, `flex-col-reverse`, order + reverse composition

Full suite: 980 tests pass. `dart analyze`: no issues.

## Docs

- `doc/layout/flexbox.md` — new "Reversing Direction" and "Child Order" sections, updated quick-reference table
- `example/lib/pages/layout/order.dart` — interactive demo covering all variants including responsive reorder
- `CHANGELOG.md` — entries under `[Unreleased]`

## Test plan

- [x] `flutter test test/parser/parsers/order_parser_test.dart`
- [x] `flutter test test/widgets/w_div/order_test.dart`
- [x] `flutter test` (full suite)
- [x] `dart analyze`
- [ ] Manual: run `cd example && flutter run` → Layout → Order page, verify responsive reorder by resizing