### PR TITLE
feat(widgets): add WBreakpoint for per-breakpoint widget trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 ### Added
 - **Child Order**: `order-0` through `order-12`, `order-first`, `order-last`, `order-none`, and arbitrary `order-[n]` (including negatives) for reordering flex children without changing source order. Stable-sort preserves insertion order among equal-order children. (#53)
 - **Reverse Flex Direction**: `flex-row-reverse` and `flex-col-reverse` flip the main-axis direction via `Row.textDirection` / `Column.verticalDirection`, so `justify-start` mirrors to match CSS semantics (not just a visual list reversal). Applied after `order-*` sorting and works with responsive prefixes. (#53)
+- **WBreakpoint**: New widget for declarative breakpoint-keyed widget trees. Takes `base` plus optional `sm`/`md`/`lg`/`xl`/`xxl` builders and a `custom` map for user-defined screens from `WindThemeData.screens`. Walks the screen chain descending, returns the builder for the highest breakpoint ≤ active width, falls back to `base`. Escape hatch for cases where className prefixes aren't enough (different widget types, different child counts). (#55)
 
 ### 🐛 Bug Fixes
 

--- a/doc/widgets/w-breakpoint.md
+++ b/doc/widgets/w-breakpoint.md
@@ -1,0 +1,142 @@
+# WBreakpoint
+
+Declarative breakpoint-keyed builder for rendering different widget trees per responsive breakpoint. An **escape hatch** for cases where the widget structure genuinely differs between breakpoints — reach for className prefixes first.
+
+- [Basic Usage](#basic-usage)
+- [When to Use](#when-to-use)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Resolution Semantics](#resolution-semantics)
+- [Custom Breakpoints](#custom-breakpoints)
+- [Nested Theme Overrides](#nested-theme-overrides)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="widgets/w_breakpoint" size="md" source="example/lib/pages/widgets/w_breakpoint.dart"></x-preview>
+
+```dart
+WBreakpoint(
+  base: (ctx) => const MobileLayout(),
+  md: (ctx) => const TabletLayout(),
+  lg: (ctx) => const DesktopLayout(),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WBreakpoint` picks one widget tree per breakpoint using Wind's own breakpoint resolution. `base` is required; other builders are optional fallbacks.
+
+```dart
+WBreakpoint(
+  base: (ctx) => WDiv(
+    className: 'flex flex-col gap-2',
+    children: [/* stacked cards */],
+  ),
+  md: (ctx) => WDiv(
+    className: 'grid grid-cols-3 gap-4',
+    children: [/* grid cards */],
+  ),
+)
+```
+
+<a name="when-to-use"></a>
+## When to Use
+
+Prefer className-first patterns. `WBreakpoint` is a last resort:
+
+| Need | Prefer |
+|:-----|:-------|
+| Swap styles per breakpoint | `sm:flex-row`, `md:gap-8` |
+| Swap visibility per breakpoint | `hidden sm:block` / `block sm:hidden` |
+| Reorder flex children | `order-2 md:order-1` |
+| Render different widget **types** | `WBreakpoint` |
+| Render different child **counts** | `WBreakpoint` |
+
+If your two branches differ only in className, use prefixes instead — you'll get less code and a cleaner diff.
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+const WBreakpoint({
+  Key? key,
+  required WidgetBuilder base,
+  WidgetBuilder? sm,
+  WidgetBuilder? md,
+  WidgetBuilder? lg,
+  WidgetBuilder? xl,
+  WidgetBuilder? xxl,
+  Map<String, WidgetBuilder> custom = const {},
+})
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| `base` | `WidgetBuilder` | **Required** | Fallback builder when no higher breakpoint matches. |
+| `sm` | `WidgetBuilder?` | `null` | Builder for `sm` breakpoint (default min width 640). |
+| `md` | `WidgetBuilder?` | `null` | Builder for `md` breakpoint (default min width 768). |
+| `lg` | `WidgetBuilder?` | `null` | Builder for `lg` breakpoint (default min width 1024). |
+| `xl` | `WidgetBuilder?` | `null` | Builder for `xl` breakpoint (default min width 1280). |
+| `xxl` | `WidgetBuilder?` | `null` | Builder for `2xl` breakpoint (default min width 1536). |
+| `custom` | `Map<String, WidgetBuilder>` | `{}` | Builders for custom breakpoint keys defined in `WindThemeData.screens`. |
+
+<a name="resolution-semantics"></a>
+## Resolution Semantics
+
+1. Read the active breakpoint from the `WindContext`.
+2. Collect all breakpoints defined in `WindThemeData.screens` that are at or below the active width.
+3. Sort them descending and pick the first one that has a builder.
+4. Fall back to `base` if nothing matches.
+
+Given default screens and width `1200` (active = `lg`):
+
+```dart
+WBreakpoint(
+  base: (_) => A(),
+  sm: (_) => B(),
+  md: (_) => C(),
+)
+// Resolution walks lg → md → sm. md has a builder → renders C().
+```
+
+<a name="custom-breakpoints"></a>
+## Custom Breakpoints
+
+Define your own screen in `WindThemeData.screens` and drive `WBreakpoint` through the `custom` map:
+
+```dart
+WindTheme(
+  data: WindThemeData().copyWith(
+    screens: const {
+      'sm': 640,
+      'md': 768,
+      'tablet': 900, // custom
+      'lg': 1024,
+      'xl': 1280,
+      '2xl': 1536,
+    },
+  ),
+  child: WBreakpoint(
+    base: (_) => const MobileTable(),
+    custom: {'tablet': (_) => const TabletTable()},
+    lg: (_) => const DesktopTable(),
+  ),
+)
+```
+
+Custom keys participate in the same descending resolution as built-ins.
+
+<a name="nested-theme-overrides"></a>
+## Nested Theme Overrides
+
+`WBreakpoint` reads through any `WindTheme` ancestor, so a nested `WindTheme` override with its own `screens` map applies inside that subtree. Useful for design-system playgrounds and test harnesses.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Responsive Design](../layout/responsive.md)
+- [Flexbox & Layout](../layout/flexbox.md)
+- [WindTheme](../theme/wind-theme.md)

--- a/example/lib/pages/widgets/w_breakpoint.dart
+++ b/example/lib/pages/widgets/w_breakpoint.dart
@@ -10,6 +10,7 @@ class WBreakpointExamplePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return WDiv(
       className: 'w-full h-full overflow-y-auto p-4',
+      scrollPrimary: true,
       child: WDiv(
         className: 'flex flex-col gap-6 max-w-3xl',
         children: [

--- a/example/lib/pages/widgets/w_breakpoint.dart
+++ b/example/lib/pages/widgets/w_breakpoint.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+/// WBreakpoint Example
+/// Demonstrates declarative per-breakpoint widget trees.
+class WBreakpointExamplePage extends StatelessWidget {
+  const WBreakpointExamplePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WDiv(
+      className: 'w-full h-full overflow-y-auto p-4',
+      child: WDiv(
+        className: 'flex flex-col gap-6 max-w-3xl',
+        children: [
+          WDiv(
+            className: '''
+              w-full p-4 rounded-xl
+              bg-gradient-to-r from-indigo-500 to-violet-500
+            ''',
+            children: [
+              WText(
+                'WBreakpoint',
+                className: 'text-lg font-bold text-white',
+              ),
+              WText(
+                'Render different widget trees per breakpoint. Resize to see it switch.',
+                className: 'text-sm text-indigo-100',
+              ),
+            ],
+          ),
+          _buildSection(
+            title: 'Different tree per breakpoint',
+            description:
+                'Stacked column on small screens, horizontal row on md+.',
+            child: WBreakpoint(
+              base: (_) => WDiv(
+                className:
+                    'flex flex-col gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+                children: [
+                  _tag('A', 'bg-rose-500'),
+                  _tag('B', 'bg-rose-500'),
+                  _tag('C', 'bg-rose-500'),
+                ],
+              ),
+              md: (_) => WDiv(
+                className:
+                    'flex gap-2 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+                children: [
+                  _tag('A', 'bg-emerald-500'),
+                  _tag('B', 'bg-emerald-500'),
+                  _tag('C', 'bg-emerald-500'),
+                ],
+              ),
+            ),
+          ),
+          _buildSection(
+            title: 'Different child counts',
+            description:
+                'Mobile shows a compact summary; wider breakpoints add detail columns.',
+            child: WBreakpoint(
+              base: (_) => WDiv(
+                className:
+                    'p-4 bg-gray-100 dark:bg-slate-700 rounded-lg flex flex-col gap-1',
+                children: [
+                  WText('Total revenue',
+                      className:
+                          'text-xs text-gray-500 dark:text-gray-300 uppercase'),
+                  WText('\$12,430',
+                      className:
+                          'text-2xl font-bold text-gray-900 dark:text-white'),
+                ],
+              ),
+              md: (_) => WDiv(
+                className:
+                    'grid grid-cols-3 gap-4 p-4 bg-gray-100 dark:bg-slate-700 rounded-lg',
+                children: [
+                  _statCard('Revenue', '\$12,430', 'bg-emerald-500'),
+                  _statCard('Users', '8,210', 'bg-sky-500'),
+                  _statCard('Orders', '1,284', 'bg-violet-500'),
+                ],
+              ),
+            ),
+          ),
+          _buildSection(
+            title: 'Fallback chain (lg width, only md defined)',
+            description:
+                'Walks from active down to any defined lower builder. Here md wins because lg is not provided.',
+            child: WBreakpoint(
+              base: (_) => _infoBox('BASE builder', 'bg-gray-500'),
+              md: (_) => _infoBox('MD builder', 'bg-indigo-500'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required String description,
+    required Widget child,
+  }) {
+    return WDiv(
+      className: 'flex flex-col gap-2',
+      children: [
+        WText(
+          title,
+          className: 'text-lg font-semibold text-gray-900 dark:text-white',
+        ),
+        WText(
+          description,
+          className: 'text-sm text-gray-600 dark:text-gray-400 mb-2',
+        ),
+        child,
+      ],
+    );
+  }
+
+  Widget _tag(String label, String bg) {
+    return WDiv(
+      className: '$bg px-4 h-10 rounded-lg flex items-center justify-center',
+      child: WText(label, className: 'text-white font-bold'),
+    );
+  }
+
+  Widget _infoBox(String label, String bg) {
+    return WDiv(
+      className: '$bg p-4 rounded-lg',
+      child: WText(label, className: 'text-white font-semibold'),
+    );
+  }
+
+  Widget _statCard(String label, String value, String bg) {
+    return WDiv(
+      className: '$bg p-3 rounded-lg flex flex-col gap-1',
+      children: [
+        WText(label, className: 'text-xs text-white/80 uppercase'),
+        WText(value, className: 'text-xl font-bold text-white'),
+      ],
+    );
+  }
+}

--- a/lib/fluttersdk_wind.dart
+++ b/lib/fluttersdk_wind.dart
@@ -116,6 +116,7 @@ export 'src/widgets/w_date_picker.dart';
 export 'src/widgets/w_form_date_picker.dart';
 export 'src/widgets/w_keyboard_actions.dart';
 export 'src/widgets/w_spacer.dart';
+export 'src/widgets/w_breakpoint.dart';
 export 'src/dynamic/w_dynamic.dart';
 export 'src/dynamic/w_dynamic_controller.dart';
 export 'src/dynamic/w_dynamic_state.dart';

--- a/lib/src/widgets/w_breakpoint.dart
+++ b/lib/src/widgets/w_breakpoint.dart
@@ -21,10 +21,11 @@ import '../parser/wind_context.dart';
 /// ### Resolution Semantics
 ///
 /// 1. Reads active breakpoint via [WindContext.build].
-/// 2. Walks the sorted breakpoint chain (ascending by min width).
-/// 3. Returns the builder for the highest defined breakpoint ≤ the active
-///    breakpoint.
-/// 4. Falls back to [base] if no higher builder matches.
+/// 2. Walks the breakpoint chain in descending order by min width, restricted
+///    to breakpoints whose min width ≤ the active breakpoint's min width.
+/// 3. Returns the first builder found — i.e. the builder for the highest
+///    defined breakpoint that is still ≤ the active breakpoint.
+/// 4. Falls back to [base] if no matching builder exists.
 ///
 /// ### Supported Features:
 /// - Built-in breakpoints: `base`, `sm`, `md`, `lg`, `xl`, `xxl` (named args)
@@ -109,6 +110,19 @@ class WBreakpoint extends StatelessWidget {
         .where((e) => e.value <= (screens[ctx.activeBreakpoint] ?? 0))
         .toList()
       ..sort((a, b) => b.value.compareTo(a.value));
+
+    assert(() {
+      for (final key in custom.keys) {
+        if (!screens.containsKey(key)) {
+          throw FlutterError(
+            'WBreakpoint: custom breakpoint "$key" is not defined in '
+            'WindThemeData.screens. Register it on the theme first, or remove '
+            'it from the custom map. Known screens: ${screens.keys.toList()}.',
+          );
+        }
+      }
+      return true;
+    }());
 
     for (final entry in sortedActive) {
       final builder = builders[entry.key];

--- a/lib/src/widgets/w_breakpoint.dart
+++ b/lib/src/widgets/w_breakpoint.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+
+import '../parser/wind_context.dart';
+
+/// **Declarative Breakpoint-Keyed Builder**
+///
+/// `WBreakpoint` renders a different widget tree per responsive breakpoint,
+/// using Wind's own breakpoint resolution (`WindContext.activeBreakpoint`)
+/// so `WindThemeData.screens` overrides and custom screens are honored.
+///
+/// This is an **escape hatch**. Prefer className-first solutions when the
+/// difference is purely stylistic:
+/// - `sm:flex-row`, `md:gap-8` — swap styles per breakpoint
+/// - `hidden sm:block` / `block sm:hidden` — swap visibility per breakpoint
+/// - `order-2 md:order-1` — reorder flex children per breakpoint
+///
+/// Reach for `WBreakpoint` only when the widget **tree structure** genuinely
+/// differs per breakpoint (different widget types, different child counts,
+/// fundamentally different layouts).
+///
+/// ### Resolution Semantics
+///
+/// 1. Reads active breakpoint via [WindContext.build].
+/// 2. Walks the sorted breakpoint chain (ascending by min width).
+/// 3. Returns the builder for the highest defined breakpoint ≤ the active
+///    breakpoint.
+/// 4. Falls back to [base] if no higher builder matches.
+///
+/// ### Supported Features:
+/// - Built-in breakpoints: `base`, `sm`, `md`, `lg`, `xl`, `xxl` (named args)
+/// - Custom breakpoints via [custom] map (uses `WindThemeData.screens` keys)
+/// - Rebuilds naturally on `MediaQuery.size` changes
+/// - Respects nested `WindTheme` overrides and test harnesses
+///
+/// ### Example Usage:
+///
+/// ```dart
+/// // Built-in breakpoints
+/// WBreakpoint(
+///   base: (ctx) => const MobileTabsScrollable(),
+///   sm:   (ctx) => const DistributedTabs(),
+/// )
+///
+/// // Custom breakpoint from WindThemeData.screens
+/// WBreakpoint(
+///   base: (ctx)   => const MobileTable(),
+///   custom: {
+///     'tablet': (ctx) => const TabletTable(),
+///   },
+///   lg: (ctx) => const DesktopTable(),
+/// )
+/// ```
+class WBreakpoint extends StatelessWidget {
+  const WBreakpoint({
+    super.key,
+    required this.base,
+    this.sm,
+    this.md,
+    this.lg,
+    this.xl,
+    this.xxl,
+    this.custom = const {},
+  });
+
+  /// Fallback builder. Used when no higher breakpoint builder matches.
+  final WidgetBuilder base;
+
+  /// Builder for the `sm` breakpoint (default min width 640).
+  final WidgetBuilder? sm;
+
+  /// Builder for the `md` breakpoint (default min width 768).
+  final WidgetBuilder? md;
+
+  /// Builder for the `lg` breakpoint (default min width 1024).
+  final WidgetBuilder? lg;
+
+  /// Builder for the `xl` breakpoint (default min width 1280).
+  final WidgetBuilder? xl;
+
+  /// Builder for the `2xl` breakpoint (default min width 1536). Named `xxl`
+  /// because Dart identifiers cannot start with a digit; mapped to `2xl` in
+  /// `WindThemeData.screens`.
+  final WidgetBuilder? xxl;
+
+  /// Builders for custom breakpoint keys defined in `WindThemeData.screens`.
+  /// Keys must match exactly (e.g. `'tablet'`, `'wide'`).
+  final Map<String, WidgetBuilder> custom;
+
+  @override
+  Widget build(BuildContext context) {
+    final windContext = WindContext.build(context);
+    return _resolve(windContext)(context);
+  }
+
+  WidgetBuilder _resolve(WindContext ctx) {
+    final builders = <String, WidgetBuilder>{
+      if (sm != null) 'sm': sm!,
+      if (md != null) 'md': md!,
+      if (lg != null) 'lg': lg!,
+      if (xl != null) 'xl': xl!,
+      if (xxl != null) '2xl': xxl!,
+      ...custom,
+    };
+
+    if (builders.isEmpty) return base;
+
+    final screens = ctx.theme.screens;
+    final sortedActive = screens.entries
+        .where((e) => e.value <= (screens[ctx.activeBreakpoint] ?? 0))
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    for (final entry in sortedActive) {
+      final builder = builders[entry.key];
+      if (builder != null) return builder;
+    }
+
+    return base;
+  }
+}

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -164,6 +164,7 @@ WDiv(
 | `WFormDatePicker`| (FormField) | `mode`, `className`, `firstDate`, `lastDate` | MagicForm-integrated date picker|
 | `WSpacer` | - | `className` | Semantic spacing between siblings |
 | `WDynamic` | `json` | `actions`, `controller`, `customIcons`, `builders`, `denyWidgets` | Server-driven UI from JSON |
+| `WBreakpoint` | `base` (builder) | `sm`, `md`, `lg`, `xl`, `xxl`, `custom` | Render a fully different widget tree per breakpoint — escape hatch when className prefixes + `hidden` aren't enough |
 
 **Rules:**
 - `child` and `children` are mutually exclusive on `WDiv`.
@@ -449,6 +450,7 @@ Before delivering any Wind UI code, run these checks:
 | `references/theme-setup.md` | WindTheme setup, dark mode, custom colors, context extensions | Theme configuration |
 | `references/component-patterns.md`| Card, button, badge, empty state, modal, nav components | Building UI components |
 | `references/design-culture.md`| iOS HIG, visual hierarchy, color theory, mobile patterns | Before any UI design work, component decisions, navigation patterns |
+| `references/responsive-decision-tree.md`| Step-by-step guide for choosing between className prefixes, `hidden`, `context.wIs*`, and `WBreakpoint` | Deciding how to vary layout by screen size |
 
 ## 13. Community Support
 

--- a/skills/wind-ui/references/responsive-decision-tree.md
+++ b/skills/wind-ui/references/responsive-decision-tree.md
@@ -1,0 +1,114 @@
+# Responsive Decision Tree
+
+When a layout needs to behave differently at different breakpoints, pick the **lowest-friction** tool that solves the problem. Jumping to `WBreakpoint` too early creates noisy, imperative code where a one-token prefix would do.
+
+## Step 1: Is it purely stylistic?
+
+If the widget tree is identical and only styles change, use **className prefixes**. No widget swap needed.
+
+```dart
+// Column on mobile, row on md+
+WDiv(className: 'flex flex-col md:flex-row gap-2 md:gap-4')
+
+// Tighter padding on small screens
+WDiv(className: 'p-2 md:p-6')
+
+// Different colors per breakpoint
+WDiv(className: 'bg-gray-100 md:bg-white')
+```
+
+## Step 2: Does something need to appear or disappear?
+
+Use **`hidden` + visibility prefixes** to swap which elements render. Same tree shape, just gated visibility.
+
+```dart
+// Mobile hamburger vs desktop nav bar
+WDiv(
+  className: 'flex',
+  children: [
+    WDiv(className: 'block md:hidden', child: const HamburgerButton()),
+    WDiv(className: 'hidden md:flex gap-4', children: [/* nav links */]),
+  ],
+)
+```
+
+## Step 3: Do children need to reorder?
+
+Use **`order-*` utilities** on flex children — no widget swap, no duplicate subtrees.
+
+```dart
+// Sidebar above content on mobile, beside it on md+
+WDiv(
+  className: 'flex flex-col md:flex-row gap-4',
+  children: [
+    WDiv(className: 'order-2 md:order-1', child: const Sidebar()),
+    WDiv(className: 'order-1 md:order-2 flex-1', child: const Main()),
+  ],
+)
+```
+
+Combine with `flex-row-reverse` / `flex-col-reverse` for whole-container flips.
+
+## Step 4: Only now — `WBreakpoint`
+
+Reach for `WBreakpoint` when the **widget tree structure** genuinely differs:
+- Different widget **types** per breakpoint (not just different classNames)
+- Different **child counts** per breakpoint
+- A completely different layout component per breakpoint
+
+```dart
+// Mobile: horizontally scrollable tabs. Desktop: distributed tab row.
+WBreakpoint(
+  base: (ctx) => const MobileScrollableTabs(),
+  md: (ctx) => const DesktopDistributedTabs(),
+)
+
+// Mobile: summary card. Desktop: 3-column stat grid.
+WBreakpoint(
+  base: (ctx) => const SummaryCard(),
+  md: (ctx) => const StatGrid(),
+)
+```
+
+## Red flags that you reached too early
+
+If your `WBreakpoint` branches look like this, go back to Step 1:
+
+```dart
+// ❌ Anti-pattern: only className differs
+WBreakpoint(
+  base: (_) => WDiv(className: 'flex flex-col gap-2', children: items),
+  md:   (_) => WDiv(className: 'flex gap-4', children: items),
+)
+
+// ✅ Replace with:
+WDiv(className: 'flex flex-col md:flex-row gap-2 md:gap-4', children: items)
+```
+
+```dart
+// ❌ Anti-pattern: only one child is hidden
+WBreakpoint(
+  base: (_) => const Menu(),
+  md:   (_) => Row(children: [const Menu(), const Banner()]),
+)
+
+// ✅ Replace with:
+WDiv(
+  className: 'flex',
+  children: [
+    const Menu(),
+    WDiv(className: 'hidden md:block', child: const Banner()),
+  ],
+)
+```
+
+## Summary
+
+| Situation | Tool |
+|:----------|:-----|
+| Style values differ | className prefix (`md:`, `lg:`) |
+| Elements appear/disappear | `hidden` + visibility prefixes |
+| Children reorder | `order-*`, `flex-*-reverse` |
+| Widget **tree** differs | `WBreakpoint` |
+
+Every step up costs more tokens and more cognitive load. Stop at the first one that solves the problem.

--- a/test/widgets/w_breakpoint_test.dart
+++ b/test/widgets/w_breakpoint_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+Widget _wrap({
+  required Size size,
+  WindThemeData? theme,
+  required Widget child,
+}) {
+  return MediaQuery(
+    data: MediaQueryData(size: size),
+    child: MaterialApp(
+      home: WindTheme(
+        data: theme ?? WindThemeData(),
+        child: Scaffold(body: child),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('WBreakpoint resolution', () {
+    testWidgets('falls back to base when no higher builder matches',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(320, 800),
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            md: (_) => const Text('MD'),
+          ),
+        ),
+      );
+
+      expect(find.text('BASE'), findsOneWidget);
+      expect(find.text('MD'), findsNothing);
+    });
+
+    testWidgets('resolves sm builder at sm width', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(700, 800),
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            sm: (_) => const Text('SM'),
+          ),
+        ),
+      );
+
+      expect(find.text('SM'), findsOneWidget);
+    });
+
+    testWidgets('picks highest defined builder ≤ active breakpoint',
+        (tester) async {
+      // lg width (>=1024), but only sm and md defined → md wins
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(1200, 800),
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            sm: (_) => const Text('SM'),
+            md: (_) => const Text('MD'),
+          ),
+        ),
+      );
+
+      expect(find.text('MD'), findsOneWidget);
+    });
+
+    testWidgets('xl width with all built-ins picks xl', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(1400, 800),
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            sm: (_) => const Text('SM'),
+            md: (_) => const Text('MD'),
+            lg: (_) => const Text('LG'),
+            xl: (_) => const Text('XL'),
+            xxl: (_) => const Text('2XL'),
+          ),
+        ),
+      );
+
+      expect(find.text('XL'), findsOneWidget);
+    });
+
+    testWidgets('2xl width picks xxl builder', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(1600, 800),
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            xxl: (_) => const Text('2XL'),
+          ),
+        ),
+      );
+
+      expect(find.text('2XL'), findsOneWidget);
+    });
+
+    testWidgets('custom breakpoint from WindThemeData.screens resolves',
+        (tester) async {
+      final theme = WindThemeData().copyWith(
+        screens: const {
+          'sm': 640,
+          'md': 768,
+          'tablet': 900,
+          'lg': 1024,
+          'xl': 1280,
+          '2xl': 1536,
+        },
+      );
+
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(950, 800),
+          theme: theme,
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            md: (_) => const Text('MD'),
+            custom: {'tablet': (_) => const Text('TABLET')},
+          ),
+        ),
+      );
+
+      expect(find.text('TABLET'), findsOneWidget);
+    });
+
+    testWidgets('custom key falls through to lower built-in when undefined',
+        (tester) async {
+      final theme = WindThemeData().copyWith(
+        screens: const {
+          'sm': 640,
+          'md': 768,
+          'tablet': 900,
+          'lg': 1024,
+          'xl': 1280,
+          '2xl': 1536,
+        },
+      );
+
+      // At tablet width, but only md defined → md resolves.
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(950, 800),
+          theme: theme,
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            md: (_) => const Text('MD'),
+          ),
+        ),
+      );
+
+      expect(find.text('MD'), findsOneWidget);
+    });
+
+    testWidgets('no builders besides base returns base', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          size: const Size(1200, 800),
+          child: WBreakpoint(base: (_) => const Text('BASE')),
+        ),
+      );
+
+      expect(find.text('BASE'), findsOneWidget);
+    });
+
+    testWidgets('rebuilds when size crosses breakpoint', (tester) async {
+      Widget app(Size size) => _wrap(
+            size: size,
+            child: WBreakpoint(
+              base: (_) => const Text('BASE'),
+              md: (_) => const Text('MD'),
+            ),
+          );
+
+      await tester.pumpWidget(app(const Size(400, 800)));
+      expect(find.text('BASE'), findsOneWidget);
+
+      await tester.pumpWidget(app(const Size(900, 800)));
+      expect(find.text('MD'), findsOneWidget);
+    });
+
+    testWidgets('respects nested WindTheme override', (tester) async {
+      final innerTheme = WindThemeData().copyWith(
+        screens: const {
+          'sm': 100,
+          'md': 200,
+          'lg': 300,
+          'xl': 400,
+          '2xl': 500,
+        },
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(250, 800)),
+          child: MaterialApp(
+            home: WindTheme(
+              data: WindThemeData(),
+              child: WindTheme(
+                data: innerTheme,
+                child: Scaffold(
+                  body: WBreakpoint(
+                    base: (_) => const Text('BASE'),
+                    md: (_) => const Text('MD'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // At 250px with inner screens, md (200) matches.
+      expect(find.text('MD'), findsOneWidget);
+    });
+  });
+}

--- a/test/widgets/w_breakpoint_test.dart
+++ b/test/widgets/w_breakpoint_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluttersdk_wind/fluttersdk_wind.dart';
 
-Widget _wrap({
+Widget wrapWithTheme({
   required Size size,
   WindThemeData? theme,
   required Widget child,
@@ -19,11 +19,15 @@ Widget _wrap({
 }
 
 void main() {
+  setUp(() {
+    WindParser.clearCache();
+  });
+
   group('WBreakpoint resolution', () {
     testWidgets('falls back to base when no higher builder matches',
         (tester) async {
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(320, 800),
           child: WBreakpoint(
             base: (_) => const Text('BASE'),
@@ -38,7 +42,7 @@ void main() {
 
     testWidgets('resolves sm builder at sm width', (tester) async {
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(700, 800),
           child: WBreakpoint(
             base: (_) => const Text('BASE'),
@@ -54,7 +58,7 @@ void main() {
         (tester) async {
       // lg width (>=1024), but only sm and md defined → md wins
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(1200, 800),
           child: WBreakpoint(
             base: (_) => const Text('BASE'),
@@ -69,7 +73,7 @@ void main() {
 
     testWidgets('xl width with all built-ins picks xl', (tester) async {
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(1400, 800),
           child: WBreakpoint(
             base: (_) => const Text('BASE'),
@@ -87,7 +91,7 @@ void main() {
 
     testWidgets('2xl width picks xxl builder', (tester) async {
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(1600, 800),
           child: WBreakpoint(
             base: (_) => const Text('BASE'),
@@ -113,7 +117,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(950, 800),
           theme: theme,
           child: WBreakpoint(
@@ -142,7 +146,7 @@ void main() {
 
       // At tablet width, but only md defined → md resolves.
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(950, 800),
           theme: theme,
           child: WBreakpoint(
@@ -157,7 +161,7 @@ void main() {
 
     testWidgets('no builders besides base returns base', (tester) async {
       await tester.pumpWidget(
-        _wrap(
+        wrapWithTheme(
           size: const Size(1200, 800),
           child: WBreakpoint(base: (_) => const Text('BASE')),
         ),
@@ -167,7 +171,7 @@ void main() {
     });
 
     testWidgets('rebuilds when size crosses breakpoint', (tester) async {
-      Widget app(Size size) => _wrap(
+      Widget app(Size size) => wrapWithTheme(
             size: size,
             child: WBreakpoint(
               base: (_) => const Text('BASE'),
@@ -215,6 +219,21 @@ void main() {
 
       // At 250px with inner screens, md (200) matches.
       expect(find.text('MD'), findsOneWidget);
+    });
+
+    testWidgets('asserts when custom key is missing from theme screens',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithTheme(
+          size: const Size(800, 800),
+          child: WBreakpoint(
+            base: (_) => const Text('BASE'),
+            custom: {'unregistered': (_) => const Text('CUSTOM')},
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isA<FlutterError>());
     });
   });
 }


### PR DESCRIPTION
Closes #55.

## Summary

Adds `WBreakpoint`, a thin widget that renders a different widget tree per responsive breakpoint using Wind's own breakpoint resolution (`WindContext.activeBreakpoint`). Honors `WindThemeData.screens` overrides and custom screens natively, avoiding the `MediaQuery.of(context).size.width >= 640` magic-number ternaries.

## API

\`\`\`dart
WBreakpoint(
  base: (ctx) => const MobileLayout(),
  sm: (ctx) => const CompactLayout(),
  md: (ctx) => const TabletLayout(),
  lg: (ctx) => const DesktopLayout(),
  custom: {'tablet': (ctx) => const TabletLayout()},
)
\`\`\`

Built-in args: `base` (required), `sm`, `md`, `lg`, `xl`, `xxl` (maps to `2xl` since Dart identifiers can't start with a digit). Custom screens go in `custom: {...}` and participate in the same descending chain.

## Resolution

1. Read active breakpoint from `WindContext.build(context)`.
2. Collect screens defined in `WindThemeData.screens` whose value ≤ the active breakpoint's value.
3. Sort descending and pick the first screen that has a builder.
4. Fall back to `base`.

This means: if only `md` is defined but width is `lg`, `md` renders — exactly what the issue spec describes.

## Positioning as an Escape Hatch

The issue explicitly asked for skill/doc guidance steering authors away from overuse. The new `skills/wind-ui/references/responsive-decision-tree.md` is a 4-step ladder:

1. Stylistic difference only → `md:` / `sm:` className prefixes
2. Elements appear/disappear → `hidden sm:block`
3. Reorder children → `order-*`, `flex-*-reverse`
4. Widget tree structure differs → `WBreakpoint`

Red-flag anti-patterns (branches that differ only in className) are shown with their className-prefix rewrites.

## Tests

`test/widgets/w_breakpoint_test.dart` — 10 cases:
- fallback to `base` when no higher builder matches
- resolves `sm` at sm width
- picks highest defined builder ≤ active breakpoint
- full built-in chain picks correct one at xl
- 2xl width resolves `xxl`
- custom breakpoint from `WindThemeData.screens` resolves
- custom key undefined falls through to lower built-in
- only `base` → returns base
- rebuilds when MediaQuery size crosses a breakpoint
- respects nested `WindTheme` override with custom screens

Full suite: 968 tests pass. `dart analyze`: no issues.

## Docs

- `doc/widgets/w-breakpoint.md` — full page with resolution semantics, custom breakpoints, nested theme, when-to-use table
- `example/lib/pages/widgets/w_breakpoint.dart` — interactive page with structurally different trees per breakpoint
- `skills/wind-ui/references/responsive-decision-tree.md` — LLM guidance ladder
- `CHANGELOG.md` — entry under `[Unreleased]`

## Acceptance Criteria (from #55)

- [x] Resolves built-in breakpoints in ascending chain (pick highest ≤ active)
- [x] Custom breakpoints via `custom: {...}` resolve using `WindThemeData.screens`
- [x] Rebuilds when MediaQuery.size crosses a breakpoint, stable otherwise
- [x] Works inside nested `WindTheme` overrides
- [x] Missing builders tree-shake (null builders aren't collected)
- [x] Example page at `example/lib/pages/widgets/w_breakpoint.dart`
- [x] Docs page at `doc/widgets/w-breakpoint.md`
- [x] Skill guidance at `skills/wind-ui/references/responsive-decision-tree.md`

## Test plan

- [x] `flutter test test/widgets/w_breakpoint_test.dart`
- [x] `flutter test` (full suite)
- [x] `dart analyze`
- [ ] Manual: run example, resize window across sm/md/lg and verify tree swaps

## Upstream sync reminder

After merge, per CLAUDE.md the new `skills/wind-ui/references/responsive-decision-tree.md` needs to be mirrored to [`fluttersdk/ai`](https://github.com/fluttersdk/ai) at `skills/wind-ui/references/responsive-decision-tree.md`.