### PR TITLE
feat(widgets): inline backgroundColor/foregroundColor for dynamic colors (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 - **Child Order**: `order-0` through `order-12`, `order-first`, `order-last`, `order-none`, and arbitrary `order-[n]` (including negatives) for reordering flex children without changing source order. Stable-sort preserves insertion order among equal-order children. (#53)
 - **Reverse Flex Direction**: `flex-row-reverse` and `flex-col-reverse` flip the main-axis direction via `Row.textDirection` / `Column.verticalDirection`, so `justify-start` mirrors to match CSS semantics (not just a visual list reversal). Applied after `order-*` sorting and works with responsive prefixes. (#53)
 - **WBreakpoint**: New widget for declarative breakpoint-keyed widget trees. Takes `base` plus optional `sm`/`md`/`lg`/`xl`/`xxl` builders and a `custom` map for user-defined screens from `WindThemeData.screens`. Walks the screen chain descending, returns the builder for the highest breakpoint ≤ active width, falls back to `base`. Escape hatch for cases where className prefixes aren't enough (different widget types, different child counts). (#55)
+- **Inline Color Props**: `WDiv.backgroundColor` and `WText.foregroundColor` for runtime-dynamic colors (color picker, per-tenant brand). Overrides any `bg-*` / `text-*` from `className` and does not participate in the parser cache key, so a dragging color picker no longer bloats the cache the way `bg-[#$hex]` interpolation would. Added `WindParser.cacheSize` for cache-behavior assertions in tests. (#59)
 
 ### 🐛 Bug Fixes
 

--- a/doc/widgets/w-div.md
+++ b/doc/widgets/w-div.md
@@ -7,6 +7,7 @@ It embodies the "Intelligent Composition" philosophy, dynamically constructing t
 - [Basic Usage](#basic-usage)
 - [Constructor](#constructor)
 - [Props](#props)
+- [Runtime-Dynamic Colors](#runtime-dynamic-colors)
 - [Layout Modes](#layout-modes)
 - [Event Handling](#event-handling)
 - [State Variants](#state-variants)
@@ -62,6 +63,7 @@ const WDiv({
   WindStyle? style,
   Set<String>? states,
   bool scrollPrimary = false,
+  Color? backgroundColor,
 })
 ```
 
@@ -76,6 +78,25 @@ const WDiv({
 | `style` | `WindStyle?` | `null` | Explicit style object that serves as a base for `className`. |
 | `states` | `Set<String>?` | `null` | Custom states to activate prefix classes (e.g., `loading:bg-blue-500`). |
 | `scrollPrimary` | `bool` | `false` | Whether this is the primary scroll view for iOS tap-to-top and desktop scrollbar integration. |
+| `backgroundColor` | `Color?` | `null` | Inline background color for runtime-dynamic values. Overrides any `bg-*` / `dark:bg-*` from `className`. See [Runtime-Dynamic Colors](#runtime-dynamic-colors). |
+
+<a name="runtime-dynamic-colors"></a>
+## Runtime-Dynamic Colors
+
+Utility classes are for **design tokens** (`bg-primary-500`, `bg-red-500`). When the color is a **runtime value**, a hex from a color picker or a brand color loaded per tenant, use the `backgroundColor` prop instead of interpolating into `bg-[#$hex]`.
+
+```dart
+// Good: runtime-dynamic color via inline prop
+WDiv(
+  backgroundColor: userBrandColor, // Color from a picker or API
+  className: 'w-16 h-16 rounded-xl',
+)
+
+// Avoid: string interpolation bloats the parser cache, one entry per unique hex
+WDiv(className: 'w-16 h-16 rounded-xl bg-[#${userBrandColor.hex}]')
+```
+
+Precedence: inline `backgroundColor` wins over any `bg-*` / `dark:bg-*` resolved from `className`. When `backgroundColor` is `null`, className behavior, including the `dark:` fallback, is unchanged. The inline color does not participate in the parser cache key.
 
 <a name="layout-modes"></a>
 ## Layout Modes

--- a/doc/widgets/w-text.md
+++ b/doc/widgets/w-text.md
@@ -5,6 +5,7 @@ A utility-first text component that translates Tailwind-like class strings into 
 - [Basic Usage](#basic-usage)
 - [Constructor](#constructor)
 - [Props](#props)
+- [Runtime-Dynamic Colors](#runtime-dynamic-colors)
 - [Typography Styling](#typography-styling)
 - [State Variants](#state-variants)
 - [Styling Examples](#styling-examples)
@@ -43,6 +44,7 @@ const WText(
   TextStyle? textStyle,
   bool selectable = false,
   Set<String>? states,
+  Color? foregroundColor,
 })
 ```
 
@@ -56,6 +58,26 @@ const WText(
 | `textStyle` | `TextStyle?` | `null` | Standard Flutter TextStyle to merge (className takes precedence). |
 | `selectable` | `bool` | `false` | Whether the text should be selectable (renders `SelectableText`). |
 | `states` | `Set<String>?` | `null` | Custom states for dynamic styling (e.g., 'loading'). |
+| `foregroundColor` | `Color?` | `null` | Inline text color for runtime-dynamic values. Overrides any `text-*` / `dark:text-*` from `className`. See [Runtime-Dynamic Colors](#runtime-dynamic-colors). |
+
+<a name="runtime-dynamic-colors"></a>
+## Runtime-Dynamic Colors
+
+Utility classes are for **design tokens** (`text-primary-500`, `text-red-500`). When the color is a **runtime value**, a user-picked brand color or a hex loaded from an API, use the `foregroundColor` prop instead of interpolating into `text-[#$hex]`.
+
+```dart
+// Good: runtime-dynamic color via inline prop
+WText(
+  'Brand',
+  foregroundColor: userBrandColor,
+  className: 'text-lg font-bold',
+)
+
+// Avoid: string interpolation bloats the parser cache, one entry per unique hex
+WText('Brand', className: 'text-lg font-bold text-[#${userBrandColor.hex}]')
+```
+
+Precedence: inline `foregroundColor` wins over any `text-*` / `dark:text-*` resolved from `className`. When `foregroundColor` is `null`, className behavior, including the `dark:` fallback, is unchanged. The inline color does not participate in the parser cache key.
 
 ## Typography Styling
 

--- a/example/lib/pages/widgets/w_div.dart
+++ b/example/lib/pages/widgets/w_div.dart
@@ -2,8 +2,28 @@ import 'package:flutter/material.dart';
 import 'package:fluttersdk_wind/fluttersdk_wind.dart';
 
 /// WDiv Widget Showcase
-class WDivExamplePage extends StatelessWidget {
+class WDivExamplePage extends StatefulWidget {
   const WDivExamplePage({super.key});
+
+  @override
+  State<WDivExamplePage> createState() => _WDivExamplePageState();
+}
+
+class _WDivExamplePageState extends State<WDivExamplePage> {
+  // Simulates a runtime-dynamic user/brand color (e.g. from a color picker
+  // or per-tenant config). Using `bg-[#$hex]` here would create a new parser
+  // cache entry for every tap; the inline `backgroundColor` prop does not.
+  static const List<Color> _brandPalette = <Color>[
+    Color(0xFFEF4444),
+    Color(0xFF10B981),
+    Color(0xFF3B82F6),
+    Color(0xFFF59E0B),
+    Color(0xFF8B5CF6),
+  ];
+  int _brandIndex = 0;
+
+  Color get _userBrandColor =>
+      _brandPalette[_brandIndex % _brandPalette.length];
 
   @override
   Widget build(BuildContext context) {
@@ -191,6 +211,59 @@ class WDivExamplePage extends StatelessWidget {
               ],
             ),
           ]),
+
+          // Runtime-Dynamic Color
+          _section(
+            'Runtime-Dynamic Color',
+            'Use the inline backgroundColor prop for values you cannot know at '
+                'compile time (color picker, per-tenant brand).',
+            [
+              WDiv(
+                className:
+                    'flex flex-col gap-3 p-4 bg-gray-100 dark:bg-slate-800 rounded-lg',
+                children: [
+                  WDiv(
+                    className: 'flex flex-row items-center gap-3',
+                    children: [
+                      WDiv(
+                        backgroundColor: _userBrandColor,
+                        className: 'w-16 h-16 rounded-xl',
+                      ),
+                      WDiv(
+                        className: 'flex flex-col gap-1',
+                        children: [
+                          WText(
+                            'Brand swatch',
+                            className:
+                                'text-sm font-semibold text-gray-800 dark:text-white',
+                          ),
+                          WText(
+                            '#${_userBrandColor.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toUpperCase()}',
+                            className:
+                                'text-xs font-mono text-gray-500 dark:text-gray-400',
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  WAnchor(
+                    onTap: () => setState(
+                      () => _brandIndex =
+                          (_brandIndex + 1) % _brandPalette.length,
+                    ),
+                    child: const WDiv(
+                      className:
+                          'px-3 py-2 rounded-md bg-blue-500 hover:bg-blue-600',
+                      child: WText(
+                        'Cycle brand color',
+                        className: 'text-white text-sm font-medium',
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
 
           // Quick Reference
           WDiv(

--- a/example/lib/pages/widgets/w_text.dart
+++ b/example/lib/pages/widgets/w_text.dart
@@ -158,6 +158,33 @@ class WTextExamplePage extends StatelessWidget {
               ],
             ),
           ),
+          _buildSection(
+            title: 'Runtime-Dynamic Color',
+            description:
+                'Use foregroundColor for values you cannot know at compile '
+                'time (user-picked brand color, per-tenant accent). Inline '
+                'prop overrides any text-* / dark:text-* from className.',
+            child: WDiv(
+              className: 'flex flex-col gap-3',
+              children: const [
+                WText(
+                  'Tenant Acme',
+                  foregroundColor: Color(0xFFEF4444),
+                  className: 'text-xl font-bold',
+                ),
+                WText(
+                  'Tenant Globex',
+                  foregroundColor: Color(0xFF10B981),
+                  className: 'text-xl font-bold',
+                ),
+                WText(
+                  'Tenant Initech',
+                  foregroundColor: Color(0xFF3B82F6),
+                  className: 'text-xl font-bold',
+                ),
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -118,7 +118,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-alpha.4"
+    version: "1.0.0-alpha.6"
   google_fonts:
     dependency: "direct main"
     description:

--- a/lib/src/parser/wind_parser.dart
+++ b/lib/src/parser/wind_parser.dart
@@ -110,6 +110,12 @@ class WindParser {
     _styleCache.clear();
   }
 
+  /// Number of entries currently held in the style cache.
+  ///
+  /// Useful for tests that verify cache-key behavior (e.g. that inline
+  /// render-time props do not create extra cache entries).
+  static int get cacheSize => _styleCache.length;
+
   /// Parses a className string into a [WindStyle] object.
   ///
   /// This is the main entry point for style parsing. It builds a [WindContext]

--- a/lib/src/widgets/w_div.dart
+++ b/lib/src/widgets/w_div.dart
@@ -99,6 +99,17 @@ class WDiv extends StatelessWidget {
   /// Defaults to `false`.
   final bool scrollPrimary;
 
+  /// Inline background color for **runtime-dynamic** values (e.g. a color
+  /// picker, a brand color saved per tenant).
+  ///
+  /// Use `className: 'bg-*'` for static design tokens. Reach for this prop
+  /// only when the color is a runtime value that would otherwise bloat the
+  /// parser cache via `bg-[#\$hex]` interpolation.
+  ///
+  /// When non-null, this overrides any `bg-*` / `dark:bg-*` resolved from
+  /// [className]. Does NOT participate in the parser cache key.
+  final Color? backgroundColor;
+
   /// Creates a new [WDiv] instance.
   const WDiv({
     super.key,
@@ -108,6 +119,7 @@ class WDiv extends StatelessWidget {
     this.style,
     this.states,
     this.scrollPrimary = false,
+    this.backgroundColor,
   }) : assert(
           child == null || children == null,
           'WDiv Violation: You cannot provide both `child` and `children`. Please select one strategy.',
@@ -881,7 +893,8 @@ class WDiv extends StatelessWidget {
     final bool needsContainer = styles.decoration != null ||
         innerConstraints != null ||
         styles.boxShadow != null ||
-        styles.ringShadow != null;
+        styles.ringShadow != null ||
+        backgroundColor != null;
 
     // Track if padding is consumed by Container (so we don't apply it again)
     bool paddingConsumedByContainer = false;
@@ -903,6 +916,16 @@ class WDiv extends StatelessWidget {
           finalDecoration = finalDecoration.copyWith(
             boxShadow: combinedShadows,
           );
+        }
+      }
+
+      // Inline backgroundColor wins over any parsed bg-* / dark:bg-*.
+      // Applied last so it trumps className-resolved decoration color.
+      if (backgroundColor != null) {
+        if (finalDecoration == null) {
+          finalDecoration = BoxDecoration(color: backgroundColor);
+        } else {
+          finalDecoration = finalDecoration.copyWith(color: backgroundColor);
         }
       }
 

--- a/lib/src/widgets/w_div.dart
+++ b/lib/src/widgets/w_div.dart
@@ -920,12 +920,21 @@ class WDiv extends StatelessWidget {
       }
 
       // Inline backgroundColor wins over any parsed bg-* / dark:bg-*.
-      // Applied last so it trumps className-resolved decoration color.
+      // Rebuild via the constructor (not copyWith) so gradient/image are
+      // truly cleared. `BoxDecoration.copyWith` falls back to `this.x` when
+      // a named arg is null, so it cannot clear fields.
       if (backgroundColor != null) {
         if (finalDecoration == null) {
           finalDecoration = BoxDecoration(color: backgroundColor);
         } else {
-          finalDecoration = finalDecoration.copyWith(color: backgroundColor);
+          finalDecoration = BoxDecoration(
+            color: backgroundColor,
+            border: finalDecoration.border,
+            borderRadius: finalDecoration.borderRadius,
+            boxShadow: finalDecoration.boxShadow,
+            shape: finalDecoration.shape,
+            backgroundBlendMode: finalDecoration.backgroundBlendMode,
+          );
         }
       }
 

--- a/lib/src/widgets/w_text.dart
+++ b/lib/src/widgets/w_text.dart
@@ -67,6 +67,17 @@ class WText extends StatelessWidget {
   /// Custom states for dynamic state styling (e.g., 'loading', 'selected').
   final Set<String>? states;
 
+  /// Inline text color for **runtime-dynamic** values (e.g. a user-picked
+  /// brand color).
+  ///
+  /// Use `className: 'text-*'` for static design tokens. Reach for this prop
+  /// only when the color is a runtime value that would otherwise bloat the
+  /// parser cache via `text-[#\$hex]` interpolation.
+  ///
+  /// When non-null, this overrides any `text-*` / `dark:text-*` resolved
+  /// from [className]. Does NOT participate in the parser cache key.
+  final Color? foregroundColor;
+
   const WText(
     this.data, {
     super.key,
@@ -75,6 +86,7 @@ class WText extends StatelessWidget {
     this.textStyle,
     this.selectable = false,
     this.states,
+    this.foregroundColor,
   });
 
   @override
@@ -150,7 +162,12 @@ class WText extends StatelessWidget {
     // Merge with explicit `textStyle` prop.
     // Note: We do NOT manually merge with DefaultTextStyle here.
     // The `Text` widget does that automatically for null properties.
-    final TextStyle finalTextStyle = windTextStyle.merge(textStyle);
+    TextStyle finalTextStyle = windTextStyle.merge(textStyle);
+
+    // Inline foregroundColor wins over any parsed text-* / dark:text-*.
+    if (foregroundColor != null) {
+      finalTextStyle = finalTextStyle.copyWith(color: foregroundColor);
+    }
 
     // B. Apply Text Transformation (uppercase, lowercase)
     final String transformedData = _applyTextTransform(

--- a/test/widgets/w_div_test.dart
+++ b/test/widgets/w_div_test.dart
@@ -279,11 +279,13 @@ void main() {
         'paints Container color when backgroundColor is provided '
         'without any bg-* className', (tester) async {
       const color = Color(0xFF123456);
+      const testKey = Key('bg-only');
       await tester.pumpWidget(
         MaterialApp(
           home: WindTheme(
             data: WindThemeData(),
             child: const WDiv(
+              key: testKey,
               className: 'w-10 h-10',
               backgroundColor: color,
             ),
@@ -291,19 +293,27 @@ void main() {
         ),
       );
 
-      final container = tester.widget<Container>(find.byType(Container));
-      final decoration = container.decoration as BoxDecoration;
-      expect(decoration.color, color);
+      final containerFinder = find.descendant(
+        of: find.byKey(testKey),
+        matching: find.byWidgetPredicate((widget) {
+          if (widget is! Container) return false;
+          final decoration = widget.decoration;
+          return decoration is BoxDecoration && decoration.color == color;
+        }),
+      );
+      expect(containerFinder, findsOneWidget);
     });
 
     testWidgets('inline backgroundColor wins over bg-* className',
         (tester) async {
       const override = Color(0xFFABCDEF);
+      const testKey = Key('bg-override');
       await tester.pumpWidget(
         MaterialApp(
           home: WindTheme(
             data: WindThemeData(),
             child: const WDiv(
+              key: testKey,
               className: 'w-10 h-10 bg-red-500',
               backgroundColor: override,
             ),
@@ -311,9 +321,45 @@ void main() {
         ),
       );
 
-      final container = tester.widget<Container>(find.byType(Container));
+      final containerFinder = find.descendant(
+        of: find.byKey(testKey),
+        matching: find.byWidgetPredicate((widget) {
+          if (widget is! Container) return false;
+          final decoration = widget.decoration;
+          return decoration is BoxDecoration && decoration.color == override;
+        }),
+      );
+      expect(containerFinder, findsOneWidget);
+    });
+
+    testWidgets(
+        'inline backgroundColor clears className gradient so solid color '
+        'is not painted over', (tester) async {
+      const override = Color(0xFF00AA00);
+      const testKey = Key('bg-vs-gradient');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              key: testKey,
+              className: 'w-10 h-10 bg-gradient-to-r from-red-500 to-blue-500',
+              backgroundColor: override,
+            ),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(
+        find.descendant(
+          of: find.byKey(testKey),
+          matching: find.byType(Container),
+        ),
+      );
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.color, override);
+      expect(decoration.gradient, isNull);
+      expect(decoration.image, isNull);
     });
 
     testWidgets(

--- a/test/widgets/w_div_test.dart
+++ b/test/widgets/w_div_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluttersdk_wind/src/theme/wind_theme.dart';
 import 'package:fluttersdk_wind/src/theme/wind_theme_data.dart';
+import 'package:fluttersdk_wind/src/parser/wind_parser.dart';
 import 'package:fluttersdk_wind/src/widgets/w_div.dart';
 import 'package:fluttersdk_wind/src/theme/defaults/colors.dart'
     as default_colors;
@@ -267,5 +268,76 @@ void main() {
 
     // Verify we have SingleChildScrollView (from overflow-y-auto)
     expect(find.byType(SingleChildScrollView), findsOneWidget);
+  });
+
+  group('WDiv inline backgroundColor', () {
+    setUp(() {
+      WindParser.clearCache();
+    });
+
+    testWidgets(
+        'paints Container color when backgroundColor is provided '
+        'without any bg-* className', (tester) async {
+      const color = Color(0xFF123456);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'w-10 h-10',
+              backgroundColor: color,
+            ),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, color);
+    });
+
+    testWidgets('inline backgroundColor wins over bg-* className',
+        (tester) async {
+      const override = Color(0xFFABCDEF);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WDiv(
+              className: 'w-10 h-10 bg-red-500',
+              backgroundColor: override,
+            ),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, override);
+    });
+
+    testWidgets(
+        'parser cache entry is shared across WDivs with different '
+        'backgroundColor but identical className', (tester) async {
+      WindParser.clearCache();
+      const sameClass = 'w-8 h-8 rounded-md';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const Column(
+              children: [
+                WDiv(className: sameClass, backgroundColor: Color(0xFF111111)),
+                WDiv(className: sameClass, backgroundColor: Color(0xFF222222)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Two WDivs parsed the same className; only one cache entry should exist.
+      expect(WindParser.cacheSize, 1);
+    });
   });
 }

--- a/test/widgets/w_text_test.dart
+++ b/test/widgets/w_text_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttersdk_wind/src/parser/wind_parser.dart';
+import 'package:fluttersdk_wind/src/theme/wind_theme.dart';
+import 'package:fluttersdk_wind/src/theme/wind_theme_data.dart';
+import 'package:fluttersdk_wind/src/widgets/w_text.dart';
+
+void main() {
+  group('WText inline foregroundColor', () {
+    setUp(() {
+      WindParser.clearCache();
+    });
+
+    testWidgets('applies foregroundColor to Text style when no text-* class',
+        (tester) async {
+      const color = Color(0xFF112233);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WText(
+              'hello',
+              className: 'text-lg',
+              foregroundColor: color,
+            ),
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.text('hello'));
+      expect(text.style?.color, color);
+    });
+
+    testWidgets('foregroundColor wins over text-* className', (tester) async {
+      const override = Color(0xFFCC00CC);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: const WText(
+              'hello',
+              className: 'text-red-500',
+              foregroundColor: override,
+            ),
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.text('hello'));
+      expect(text.style?.color, override);
+    });
+  });
+}


### PR DESCRIPTION
Closes #59.

## Summary

- Add `WDiv.backgroundColor: Color?` and `WText.foregroundColor: Color?` as the blessed path for **runtime-dynamic** colors (color picker, per-tenant brand, hex from API).
- Inline props are applied *after* `WindParser.parse()`, so they:
  - Override any `bg-*` / `text-*` (including `dark:` variants) from `className`.
  - Do **not** participate in the parser cache key. A dragging color picker no longer bloats the cache the way `bg-[#\$hex]` interpolation would.
- Expose `WindParser.cacheSize` so tests can assert the cache-key invariant directly.
- Docs, CHANGELOG, and interactive demo pages updated.

## Acceptance (from #59)

- [x] `WDiv` gains `backgroundColor: Color?` prop.
- [x] `WText` gains `foregroundColor: Color?` prop.
- [x] Inline color wins over className when both are present (documented in `doc/widgets/w-div.md`, `doc/widgets/w-text.md`).
- [x] Cache key excludes the inline color (verified by test: two `WDiv`s with the same className and different `backgroundColor` share a single cache entry via `WindParser.cacheSize == 1`).
- [x] Docs page explains: utility classes for tokens, inline props for runtime-dynamic colors.

## Test plan

- [x] `flutter test` — 1004 tests pass, incl. 3 new WDiv cases and 2 new WText cases.
- [x] `dart analyze` (lib + test) — no issues.
- [x] `dart analyze` (example) — no issues.
- [x] `dart format .` — no diff.
- [ ] `cd example && flutter run` — manual verification: WDiv + WText pages render the "Runtime-Dynamic Color" section, brand cycling works, dark-mode fallback still applies when `backgroundColor` is null.