### PR TITLE
fix(w_input): clear OutlineInputBorder gapPadding so px-* matches inset (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- `WInput`: `px-*` horizontal padding now matches the requested value on both single-line and multiline. Previously every `OutlineInputBorder` defaulted to `gapPadding: 4.0` (Material's reservation for a floating-label cutout), adding a phantom `+4px` on each horizontal edge. Wind routes labels through the parser and never uses `InputDecoration.labelText`, so the gap had no purpose. Setting `gapPadding: 0.0` on the built border yields exact `px-*` semantics, e.g. `px-3` now produces a 12 px inset instead of 16 px. Multiline `minLines`/`maxLines` geometry unchanged. Fixes #61.
+
+---
+
 ## [1.0.0-alpha.10]
 
 ### BREAKING

--- a/lib/src/widgets/w_input.dart
+++ b/lib/src/widgets/w_input.dart
@@ -646,6 +646,11 @@ class _WInputState extends State<WInput> {
     return OutlineInputBorder(
       borderRadius: BorderRadius.circular(borderRadius),
       borderSide: BorderSide(color: borderColor, width: borderWidth),
+      // Wind routes labels through the parser instead of
+      // `InputDecoration.labelText`, so Material's default 4.0 gap reservation
+      // for a floating-label cutout has no purpose here and would add a
+      // phantom +4px on each horizontal edge over `px-*` (issue #61).
+      gapPadding: 0.0,
     );
   }
 }

--- a/test/widgets/w_input_test.dart
+++ b/test/widgets/w_input_test.dart
@@ -749,6 +749,86 @@ void main() {
     });
 
     // -------------------------------------------------------------------------
+    // Content Padding (gapPadding regression — issue #61)
+    //
+    // `OutlineInputBorder.gapPadding` defaults to 4.0 in Material to reserve
+    // space for a floating label cutout. Wind routes labels through the parser
+    // and never uses `InputDecoration.labelText`, so that reservation only
+    // adds a phantom +4px on each side. WInput must set `gapPadding: 0.0` on
+    // every OutlineInputBorder it builds so that `px-3` yields exactly 12px
+    // of horizontal inset, on both single-line and multiline.
+    // -------------------------------------------------------------------------
+    group('Content Padding', () {
+      Rect rectOf(WidgetTester tester, Finder finder) {
+        final RenderBox box = tester.renderObject<RenderBox>(finder);
+        return box.localToGlobal(Offset.zero) & box.size;
+      }
+
+      testWidgets('px-3 single-line places placeholder at 12px inset',
+          (tester) async {
+        await tester.pumpWidget(
+          wrapWithTheme(
+            const Padding(
+              padding: EdgeInsets.all(40),
+              child: WInput(
+                placeholder: 'P',
+                className: 'rounded-xl px-3 py-2.5 text-sm '
+                    'bg-white border border-gray-200',
+              ),
+            ),
+          ),
+        );
+
+        final Rect field = rectOf(tester, find.byType(TextField));
+        final Rect hint = rectOf(tester, find.text('P'));
+        expect(hint.left - field.left, 12.0);
+        expect(field.right - hint.right, 12.0);
+      });
+
+      testWidgets('px-3 multiline places placeholder at 12px inset',
+          (tester) async {
+        await tester.pumpWidget(
+          wrapWithTheme(
+            const Padding(
+              padding: EdgeInsets.all(40),
+              child: WInput(
+                placeholder: 'P',
+                type: InputType.multiline,
+                minLines: 5,
+                maxLines: 10,
+                className: 'rounded-xl px-3 py-2.5 text-sm '
+                    'bg-white border border-gray-200',
+              ),
+            ),
+          ),
+        );
+
+        final Rect field = rectOf(tester, find.byType(TextField));
+        final Rect hint = rectOf(tester, find.text('P'));
+        expect(hint.left - field.left, 12.0);
+        expect(field.right - hint.right, 12.0);
+      });
+
+      testWidgets('built OutlineInputBorder sets gapPadding to 0.0',
+          (tester) async {
+        await tester.pumpWidget(
+          wrapWithTheme(
+            const WInput(className: 'p-3 border border-gray-300 rounded-lg'),
+          ),
+        );
+
+        final TextField textField =
+            tester.widget<TextField>(find.byType(TextField));
+        final OutlineInputBorder enabled =
+            textField.decoration!.enabledBorder! as OutlineInputBorder;
+        final OutlineInputBorder base =
+            textField.decoration!.border! as OutlineInputBorder;
+        expect(enabled.gapPadding, 0.0);
+        expect(base.gapPadding, 0.0);
+      });
+    });
+
+    // -------------------------------------------------------------------------
     // Accessibility / Semantics
     //
     // Step 1 of plan ai-test-v2 contract: WInput must wrap the inner TextField


### PR DESCRIPTION
## Summary

Fixes #61. Clears the `OutlineInputBorder.gapPadding` reservation on every border `WInput` builds, so `px-*` produces the exact horizontal inset the className requests.

## Root cause

Material 3's `InputDecorator` layout adds an `inputGap = OutlineInputBorder.gapPadding` (default 4.0) to each horizontal edge of an outline-bordered `TextField`. The gap is there to reserve space for the floating-label cutout in the top border. Wind routes labels through the parser instead of `InputDecoration.labelText`, so this gap had no purpose and was producing a phantom `+4px` on every `WInput` regardless of the requested `px-*` value.

Verified via measurement (rect of placeholder vs rect of `TextField`):

| className | Type | Before | After |
|---|---|---|---|
| `px-3` (12) | single | 16 | **12** |
| `px-3` (12) | multiline | 16 | **12** |
| `px-6` (24) | single | 28 | **24** |
| `px-6` (24) | multiline | 28 | **24** |

## Notes

- The original report framed this as multiline-specific, but the `+4` extra was identical on single-line. The fix applies to both, and multiline `minLines`/`maxLines` geometry is unchanged.
- `isCollapsed: true` was considered but rejected: Material forces `contentPadding = EdgeInsets.zero` whenever `isCollapsed` is true, which would erase the user's `px-*` entirely. `gapPadding: 0.0` is the surgical fix.
- `isDense: true` was also rejected: it affects vertical padding only and does not touch the `inputGap` calculation.

## Tests

Three regression tests under `WInput Widget Tests > Content Padding`:

- `px-3 single-line places placeholder at 12px inset`
- `px-3 multiline places placeholder at 12px inset`
- `built OutlineInputBorder sets gapPadding to 0.0`

Pre-fix all three were red (actual 16.0 / 4.0). Post-fix all green.

## Verification

- `flutter test` → 1081 pass.
- `dart analyze` → No issues found.
- `dart format` → no diff on touched files.
