### PR TITLE
docs(v0): in-repo doc/ reference ported from the legacy site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 build/
+.ac/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add in-repo `doc/` reference for the 0.0.x line, ported from the legacy site docs into the 1.0.x doc-system format.
+
 ## [0.0.4] - 2025-06-12
 
 - Updated `platform_info` dependency to `^5.0.0` for improved platform detection.

--- a/doc/backgrounds/background-color.md
+++ b/doc/backgrounds/background-color.md
@@ -1,0 +1,155 @@
+# Background Color
+
+Apply background colors to widgets using predefined theme colors or arbitrary hex values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Dark Mode](#dark-mode)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="backgrounds/background_color" size="md" source="example/lib/pages/backgrounds/background_color.dart"></x-preview>
+
+```dart
+WContainer(
+  className: 'bg-blue-500 w-64 h-64 alignment-center',
+  child: WText('Blue Background', className: 'text-white'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use the `bg-` prefix followed by a color name and optional shade to apply a background color:
+
+```dart
+WContainer(
+  className: 'bg-blue-500 p-4',
+  child: WText('Blue background', className: 'text-white'),
+)
+
+WContainer(
+  className: 'bg-gray-100 dark:bg-gray-800 p-4',
+  child: WText('Light/dark aware', className: 'text-gray-900 dark:text-white'),
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Syntax
+
+```text
+bg-[color]-[shade]
+bg-[color]
+```
+
+- `color`: the color name (e.g., `red`, `blue`, `gray`). Omitting the shade defaults to `500`.
+- `shade`: the intensity — `50`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, or `900`.
+
+### Available Colors
+
+| Color | Example Class | Notes |
+|:------|:-------------|:------|
+| `slate` | `bg-slate-500` | Cool blue-gray |
+| `gray` | `bg-gray-500` | Neutral gray |
+| `zinc` | `bg-zinc-500` | Slightly warmer gray |
+| `neutral` | `bg-neutral-500` | Pure neutral |
+| `stone` | `bg-stone-500` | Warm gray |
+| `red` | `bg-red-500` | |
+| `orange` | `bg-orange-500` | |
+| `amber` | `bg-amber-500` | |
+| `yellow` | `bg-yellow-500` | |
+| `lime` | `bg-lime-500` | |
+| `green` | `bg-green-500` | |
+| `emerald` | `bg-emerald-500` | |
+| `teal` | `bg-teal-500` | |
+| `cyan` | `bg-cyan-500` | |
+| `sky` | `bg-sky-500` | |
+| `blue` | `bg-blue-500` | |
+| `indigo` | `bg-indigo-500` | |
+| `violet` | `bg-violet-500` | |
+| `purple` | `bg-purple-500` | |
+| `fuchsia` | `bg-fuchsia-500` | |
+| `pink` | `bg-pink-500` | |
+| `white` | `bg-white` | |
+| `black` | `bg-black` | |
+| `primary` | `bg-primary-500` | Alias for `indigo` |
+| `secondary` | `bg-secondary-500` | Alias for `slate` |
+
+Each color supports shades: `50`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Apply any color with a hex code using bracket notation:
+
+```text
+bg-[#rrggbb]
+```
+
+```dart
+WContainer(
+  className: 'bg-[#1abc9c] w-64 h-64 alignment-center',
+  child: WText('Custom Color Background', className: 'text-white'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any `bg-` class with a breakpoint to apply it only above that screen width:
+
+```dart
+WContainer(
+  className: 'bg-gray-100 md:bg-blue-500 lg:bg-green-500 p-4',
+  child: WText('Responsive background'),
+)
+```
+
+Available breakpoints: `sm` (640px), `md` (768px), `lg` (1024px), `xl` (1280px), `2xl` (1536px).
+
+<a name="dark-mode"></a>
+## Dark Mode
+
+Pair every light background with a `dark:` variant for automatic dark mode support:
+
+```dart
+WContainer(
+  className: 'bg-white dark:bg-gray-900 p-4',
+  child: WText(
+    'Dark-mode aware container',
+    className: 'text-gray-900 dark:text-white',
+  ),
+)
+```
+
+Wind applies dark-mode variants automatically when `WindTheme.setType(Brightness.dark)` is active.
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Add custom colors to the theme with `WindTheme.addColor`:
+
+```dart
+WindTheme.addColor('brand', MaterialColor(0xFF6200EE, {
+  50: Color(0xFFEDE7F6),
+  100: Color(0xFFD1C4E9),
+  500: Color(0xFF6200EE),
+  900: Color(0xFF311B92),
+}));
+
+WContainer(className: 'bg-brand-500 p-4', child: WText('Brand color'))
+```
+
+See [Customizing Colors](../customization/colors.md) for the full API.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Customizing Colors](../customization/colors.md) — add and override palette colors.
+- [Border Color](../borders/border-color.md) — apply color to widget borders.
+- [Text Color](../typography/text-color.md) — color utility for text.
+- [Dark Mode](../concepts/dark-mode.md) — how dark-mode inversion works in Wind.

--- a/doc/borders/border-color.md
+++ b/doc/borders/border-color.md
@@ -1,0 +1,126 @@
+# Border Color
+
+Apply colors to widget borders using predefined theme colors or arbitrary hex values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Dark Mode](#dark-mode)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="borders/border_color" size="md" source="example/lib/pages/borders/border_color.dart"></x-preview>
+
+```dart
+WContainer(
+  className: 'border-2 border-red-500 p-4',
+  child: WText('Red Border', className: 'text-blue-500'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Combine `border-[width]` with `border-[color]-[shade]` to draw a colored border:
+
+```dart
+WContainer(
+  className: 'border-2 border-blue-500 p-4',
+  child: WText('Blue border', className: 'text-blue-500'),
+)
+
+WContainer(
+  className: 'border-1 border-gray-300 dark:border-gray-600 p-4 rounded-md',
+  child: WText('Subtle border', className: 'text-gray-700 dark:text-gray-200'),
+)
+```
+
+**Note:** Wind applies border colors via `Border.all` inside `BoxDecoration`, resolved through `applyBorderColor`. Both the width class and the color class must be present for the border to render.
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Syntax
+
+```text
+border-[color]-[shade]
+border-[color]
+```
+
+- `color`: the color name. Omitting the shade defaults to `500`.
+- `shade`: `50`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, or `900`.
+
+### Example Classes
+
+| Class | Color | Shade | Description |
+|:------|:------|:------|:------------|
+| `border-red-500` | Red | 500 | Red border |
+| `border-blue-300` | Blue | 300 | Light blue border |
+| `border-gray-200` | Gray | 200 | Subtle border |
+| `border-green-700` | Green | 700 | Dark green border |
+
+For the full palette, see [Customizing Colors](../customization/colors.md).
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Apply any color with a hex code:
+
+```text
+border-[#rrggbb]
+```
+
+```dart
+WContainer(
+  className: 'border-2 border-[#1abc9c] p-4',
+  child: WText('Custom Color Border', className: 'text-blue-500'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix the border color class with a breakpoint to apply it conditionally:
+
+```dart
+WContainer(
+  className: 'border-2 border-gray-300 md:border-blue-500 p-4',
+  child: WText('Responsive border color'),
+)
+```
+
+<a name="dark-mode"></a>
+## Dark Mode
+
+Pair light border colors with `dark:` variants:
+
+```dart
+WContainer(
+  className: 'border-1 border-gray-200 dark:border-gray-700 p-4 rounded-md',
+  child: WText('Dark-mode border', className: 'text-gray-900 dark:text-white'),
+)
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Border colors use the same color palette as backgrounds. Add custom colors with `WindTheme.addColor`:
+
+```dart
+WindTheme.addColor('brand', MaterialColor(0xFF6200EE, {
+  500: Color(0xFF6200EE),
+}));
+
+WContainer(className: 'border-2 border-brand-500 p-4', child: WText('Brand border'))
+```
+
+See [Customizing Colors](../customization/colors.md) for details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Border Width](border-width.md) — control the thickness of borders.
+- [Border Radius](border-radius.md) — round the corners of widgets.
+- [Background Color](../backgrounds/background-color.md) — apply background colors.
+- [Customizing Colors](../customization/colors.md) — add and override palette colors.

--- a/doc/borders/border-radius.md
+++ b/doc/borders/border-radius.md
@@ -66,7 +66,7 @@ Size keys resolve through the REM factor. The default pixel factor is `4` and th
 Set any pixel radius with bracket notation. The value is used directly as pixels:
 
 ```text
-rounded-[[value]]
+rounded-[<value>]
 ```
 
 ```dart

--- a/doc/borders/border-radius.md
+++ b/doc/borders/border-radius.md
@@ -1,0 +1,120 @@
+# Border Radius
+
+Round widget corners with predefined size keys or arbitrary pixel values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="borders/border_radius" size="md" source="example/lib/pages/borders/border_radius.dart"></x-preview>
+
+```dart
+WContainer(
+  className: 'border-2 border-red-500 rounded-lg p-4',
+  child: WText('Rounded Border', className: 'text-blue-500'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use the `rounded-` prefix followed by a size key to clip a widget's corners:
+
+```dart
+WContainer(
+  className: 'bg-blue-500 rounded-md p-4',
+  child: WText('Medium radius', className: 'text-white'),
+)
+
+WContainer(
+  className: 'bg-indigo-600 rounded-full p-4',
+  child: WText('Pill shape', className: 'text-white'),
+)
+```
+
+**Note:** `rounded-*` applies actual clipping via `ClipRRect`, so child content is physically clipped to the border radius.
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Syntax
+
+```text
+rounded-[size]
+```
+
+Size keys resolve through the REM factor. The default pixel factor is `4` and the REM factor is `pixelFactor * 4 = 16`:
+
+| Class | REM value | Default px | Description |
+|:------|:----------|:-----------|:------------|
+| `rounded-none` | 0 | 0px | No rounding |
+| `rounded` | 0.25 | 4px | Default rounding |
+| `rounded-sm` | 0.125 | 2px | Small |
+| `rounded-md` | 0.375 | 6px | Medium |
+| `rounded-lg` | 0.5 | 8px | Large |
+| `rounded-xl` | 0.75 | 12px | Extra large |
+| `rounded-2xl` | 1.0 | 16px | 2x extra large |
+| `rounded-3xl` | 1.5 | 24px | 3x extra large |
+| `rounded-full` | — | 9999px | Fully rounded (pill/circle) |
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Set any pixel radius with bracket notation. The value is used directly as pixels:
+
+```text
+rounded-[[value]]
+```
+
+```dart
+WContainer(
+  className: 'border-2 border-red-500 rounded-[6] p-4',
+  child: WText('Custom Rounded Border', className: 'text-blue-500'),
+)
+
+WContainer(
+  className: 'bg-green-400 rounded-[20] p-4',
+  child: WText('20px radius', className: 'text-white'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Apply different radius values at different breakpoints:
+
+```dart
+WContainer(
+  className: 'rounded-sm md:rounded-lg lg:rounded-2xl p-4 bg-blue-100',
+  child: WText('Breakpoint radius'),
+)
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Override any radius key or add new ones with `WindTheme.setRoundedSize`:
+
+```dart
+// Set rounded-lg to a custom REM value
+WindTheme.setRoundedSize('lg', 0.75);
+// new px = 0.75 * remFactor (default 16) = 12px
+
+// Add a brand-specific key
+WindTheme.setRoundedSize('card', 0.625);
+// rounded-card = 0.625 * 16 = 10px
+WContainer(className: 'rounded-card bg-white p-4', ...)
+```
+
+See [Customizing Rounded Corners](../customization/rounded-corners.md) for details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Border Width](border-width.md) — control border thickness.
+- [Border Color](border-color.md) — apply color to borders.
+- [Customizing Rounded Corners](../customization/rounded-corners.md) — override the default radius scale.
+- [Pixel Factor](../customization/pixel-factor.md) — how the pixel and REM factors affect sizing.

--- a/doc/borders/border-width.md
+++ b/doc/borders/border-width.md
@@ -1,0 +1,111 @@
+# Border Width
+
+Control the thickness of widget borders. The width value maps directly to pixels.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Side-Specific Borders](#side-specific-borders)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="borders/border_width" size="md" source="example/lib/pages/borders/border_width.dart"></x-preview>
+
+```dart
+WContainer(
+  className: 'border-4 border-blue-500 p-4',
+  child: WText('Thick Border', className: 'text-blue-500'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use the `border-` prefix followed by a number to set the border width in pixels. Border widths are direct pixel values — no REM or Pixel Factor scaling is applied:
+
+```dart
+WContainer(
+  className: 'border-2 border-gray-300 p-4 rounded-md',
+  child: WText('Thin border'),
+)
+
+WContainer(
+  className: 'border-4 border-blue-500 p-4 rounded-lg',
+  child: WText('Thick border'),
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Syntax
+
+```text
+border-[width]
+```
+
+| Class | Width | Description |
+|:------|:------|:------------|
+| `border` | 1px | Default border (no number) |
+| `border-1` | 1px | 1 pixel |
+| `border-2` | 2px | 2 pixels |
+| `border-4` | 4px | 4 pixels |
+| `border-8` | 8px | 8 pixels |
+
+Any integer value works: `border-3`, `border-6`, etc.
+
+<a name="side-specific-borders"></a>
+## Side-Specific Borders
+
+Apply a border to individual sides using position suffixes:
+
+| Class | Side |
+|:------|:-----|
+| `border-t-[width]` | Top |
+| `border-b-[width]` | Bottom |
+| `border-l-[width]` | Left |
+| `border-r-[width]` | Right |
+| `border-x-[width]` | Left and right |
+| `border-y-[width]` | Top and bottom |
+
+```dart
+WContainer(
+  className: 'border-b-2 border-gray-200 p-4',
+  child: WText('Bottom border only'),
+)
+```
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation for non-standard widths. The value is used directly as pixels:
+
+```text
+border-[[value]]
+```
+
+```dart
+WContainer(
+  className: 'border-[6] border-red-400 p-4',
+  child: WText('6px border'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Adjust border width at different breakpoints:
+
+```dart
+WContainer(
+  className: 'border-1 md:border-2 lg:border-4 border-blue-500 p-4',
+  child: WText('Responsive border width'),
+)
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Border Color](border-color.md) — apply color to borders.
+- [Border Radius](border-radius.md) — round the corners of widgets.
+- [Padding](../spacing/padding.md) — inner spacing around widget content.

--- a/doc/borders/border-width.md
+++ b/doc/borders/border-width.md
@@ -81,7 +81,7 @@ WContainer(
 Use bracket notation for non-standard widths. The value is used directly as pixels:
 
 ```text
-border-[[value]]
+border-[<value>]
 ```
 
 ```dart

--- a/doc/concepts/dark-mode.md
+++ b/doc/concepts/dark-mode.md
@@ -1,0 +1,125 @@
+# Dark Mode
+
+Switch your entire app between light and dark themes with a single call. Wind automatically inverts every color in your palette, so widgets styled with `bg-gray-200` or `text-black` adapt to dark mode without rewriting their class names.
+
+- [Basic Usage](#basic-usage)
+- [How It Works](#how-it-works)
+- [The `dark:` Prefix](#the-dark-prefix)
+- [Keeping Colors Static](#keeping-colors-static)
+- [Best Practices](#best-practices)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="core/dark_mode" size="lg" source="example/lib/pages/core/dark_mode.dart"></x-preview>
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+class DarkMode extends StatefulWidget {
+  const DarkMode({super.key});
+
+  @override
+  State<DarkMode> createState() => _DarkModeState();
+}
+
+class _DarkModeState extends State<DarkMode> {
+  void enableDarkMode() {
+    setState(() {
+      WindTheme.setType(Brightness.dark);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WCard(
+      className: 'shadow-lg rounded-lg p-4 bg-white',
+      child: WFlex(
+        className: 'flex-col axis-min gap-2 items-start',
+        children: [
+          WText('12', className: 'text-4xl leading-6 font-bold text-black'),
+          WText('Active users on the website', className: 'text-black leading-4'),
+        ],
+      ),
+    );
+  }
+}
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Dark mode is driven entirely by `WindTheme`. Call `WindTheme.setType(Brightness.dark)` to switch the active brightness, then rebuild the widget tree so the new colors take effect:
+
+```dart
+setState(() {
+  WindTheme.setType(Brightness.dark);
+});
+```
+
+To follow the platform brightness instead of toggling manually, derive it from the current `BuildContext`:
+
+```dart
+WindTheme.setTypeFromContext(context);
+```
+
+You never list a separate dark palette. The colors you already use (`bg-white`, `text-black`, `bg-gray-200`) are inverted automatically the moment the brightness changes.
+
+<a name="how-it-works"></a>
+## How It Works
+
+When you call `setType`, Wind runs `WindTheme.generateDarkenColors()` under the hood. For every registered color it swaps the shade scale end-for-end, so the lightest shade becomes the darkest and vice versa:
+
+| Light value | Inverted dark value |
+|:--|:--|
+| `gray-50` | `gray-900` |
+| `gray-200` | `gray-700` |
+| `gray-500` | `gray-400` |
+| `gray-800` | `gray-100` |
+| `white` | a near-black surface |
+| `black` | `white` |
+
+The result is that a card styled `bg-white` reads as a dark surface and `text-black` reads as near-white once dark mode is active, with no extra class names. Switching back to `Brightness.light` restores the original palette.
+
+<a name="the-dark-prefix"></a>
+## The `dark:` Prefix
+
+When automatic inversion is not enough and you want an explicit dark-mode-only value, prefix any utility with `dark:`. Wind applies the prefixed class only while `WindTheme.getType()` returns `Brightness.dark`:
+
+```dart
+WCard(
+  className: 'p-4 rounded-lg bg-white dark:bg-gray-800',
+  child: WText(
+    'Adapts on its own, overridden explicitly when needed.',
+    className: 'text-gray-900 dark:text-white',
+  ),
+);
+```
+
+The `dark:` prefix and its `light:` counterpart are resolved by the screens parser, alongside the responsive `sm:`/`md:`/`lg:` breakpoints. See [Responsive Design](responsive-design.md) for the full prefix model.
+
+<a name="keeping-colors-static"></a>
+## Keeping Colors Static
+
+Some colors, a brand accent for example, should look identical in both modes. Register them with `WindTheme.addStaticColor` so they are excluded from the inversion pass:
+
+```dart
+WindTheme.addStaticColor('primary');
+WindTheme.addStaticColor('secondary');
+```
+
+A static color keeps the same shade scale regardless of the active brightness. Call `WindTheme.removeStaticColor('primary')` to opt it back into inversion.
+
+<a name="best-practices"></a>
+## Best Practices
+
+- Toggle inside `setState` (or your state-management rebuild path) so the tree repaints with the inverted palette.
+- Prefer automatic inversion first; reach for the `dark:` prefix only when a specific value should differ from the inverted default.
+- Mark brand and accent colors static with `addStaticColor` so they stay recognizable across both modes.
+- Use `setTypeFromContext` when you want Wind to follow the system or `MaterialApp` brightness rather than a manual toggle.
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Responsive Design](responsive-design.md) — the prefix model `dark:` shares with breakpoints.
+- [State-Based Styling](state-based-styling.md) — applying styles for widget states such as `hover` and `disabled`.
+- [Colors](../customization/colors.md) — registering palette colors and reading them with `wColor`.
+- [Background Color](../backgrounds/background-color.md) — the `bg-*` utilities that benefit from inversion.

--- a/doc/concepts/responsive-design.md
+++ b/doc/concepts/responsive-design.md
@@ -1,0 +1,118 @@
+# Responsive Design
+
+Adapt layouts across screen sizes with breakpoint prefixes. Inspired by TailwindCSS, Wind lets you write responsive styles such as `sm:w-full` or `lg:w-100` directly in a `className`, applied the moment the screen width crosses the matching breakpoint.
+
+- [Basic Usage](#basic-usage)
+- [Default Breakpoints](#default-breakpoints)
+- [How It Works](#how-it-works)
+- [Managing Breakpoints](#managing-breakpoints)
+- [Best Practices](#best-practices)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="core/responsive_design" size="lg" source="example/lib/pages/core/responsive_design.dart"></x-preview>
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+class ResponsiveDesign extends StatelessWidget {
+  const ResponsiveDesign({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WFlexContainer(
+      className: 'w-full h-full justify-center items-center flex-col bg-gray-200',
+      children: [
+        WCard(
+          className: 'sm:w-full lg:w-100 p-4 bg-white rounded-lg items-center justify-center',
+          child: WText('Full width on small screens, fixed on large.', className: 'text-black'),
+        ),
+        WCard(
+          className: 'lg:w-full p-4 bg-white rounded-lg items-center justify-center',
+          child: WText('Full width on large screens.', className: 'text-black'),
+        ),
+      ],
+    );
+  }
+}
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Prefix any utility with a breakpoint name to apply it from that width upward:
+
+```dart
+WCard(
+  className: 'sm:w-full md:w-1/2 lg:w-100 p-4 bg-white rounded-lg',
+  child: WText('Resizes as the viewport grows.', className: 'text-black'),
+);
+```
+
+Breakpoints are min-width based: `lg:w-100` takes effect once the available width is at least the `lg` breakpoint and stays in effect at wider sizes.
+
+<a name="default-breakpoints"></a>
+## Default Breakpoints
+
+Wind ships with five breakpoints out of the box. The width is the minimum screen width, in logical pixels, at which the prefix activates:
+
+| Prefix | Min width (px) |
+|:--|:--|
+| `sm` | 640 |
+| `md` | 768 |
+| `lg` | 1024 |
+| `xl` | 1280 |
+| `2xl` | 1536 |
+
+Retrieve the full map programmatically:
+
+```dart
+final screens = WindTheme.getScreens();
+```
+
+<a name="how-it-works"></a>
+## How It Works
+
+Wind reads each space-separated token in a `className`. When a token carries a known breakpoint prefix, the screens parser checks the current `MediaQuery` width against `WindTheme.getScreenValue(prefix)`. If the width meets or exceeds that value, the prefix is stripped and the underlying utility is applied; otherwise the token is skipped.
+
+Because the check is min-width based, listing several breakpoints lets the larger one win at wider sizes:
+
+```dart
+// w-full below lg, then a fixed 100-unit width from lg upward.
+WContainer(className: 'sm:w-full lg:w-100');
+```
+
+The same prefix machinery also resolves `dark:`/`light:` and operating-system prefixes (`ios:`, `android:`, `web:`, ...), so a single token can target a breakpoint and a mode together.
+
+<a name="managing-breakpoints"></a>
+## Managing Breakpoints
+
+Add, update, or remove custom breakpoints through `WindTheme`. Do this once during setup, before the widgets that depend on them build:
+
+```dart
+// Add a custom breakpoint.
+WindTheme.addScreen('watch', 300);
+
+// Update an existing breakpoint.
+WindTheme.updateScreen('watch', 400);
+
+// Remove a custom breakpoint.
+WindTheme.removeScreen('watch');
+```
+
+Once registered, a custom prefix behaves exactly like the built-in ones: `watch:w-full` applies from its width upward.
+
+<a name="best-practices"></a>
+## Best Practices
+
+- Order tokens from smallest to largest breakpoint so the intent reads top-down (`sm:... md:... lg:...`).
+- Remember breakpoints are min-width based: a value with no prefix is the base, and each prefix overrides it from its width upward.
+- Register custom breakpoints during app setup, not inside `build`, so the map is stable across rebuilds.
+- Combine breakpoint and mode prefixes when needed (`lg:dark:bg-gray-800`) rather than duplicating widgets.
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Dark Mode](dark-mode.md) — the `dark:` prefix that shares this resolution model.
+- [State-Based Styling](state-based-styling.md) — applying styles for widget states.
+- [Width](../sizing/width.md) — the `w-*` utilities most often made responsive.
+- [Display](../layout/display.md) — `hide`/`show` utilities with breakpoint prefixes.

--- a/doc/concepts/state-based-styling.md
+++ b/doc/concepts/state-based-styling.md
@@ -1,0 +1,137 @@
+# State-Based Styling
+
+Apply styles that react to a widget's state, such as `hover` or `disabled`, using prefixed utility classes. Wind's `classNameParser` function resolves these prefixes against the list of currently active states you pass in, so state-aware styling stays declarative.
+
+- [Basic Usage](#basic-usage)
+- [How It Works](#how-it-works)
+- [Building a Stateful Widget](#building-a-stateful-widget)
+- [Best Practices](#best-practices)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="core/state_based_styling" size="lg" source="example/lib/pages/core/state_based_styling.dart"></x-preview>
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+// Inside a widget that tracks its own active states:
+final List<String> states = [];
+if (isHovered) states.add('hover');
+if (isDisabled) states.add('disabled');
+
+final String parsed = classNameParser(
+  'bg-primary-500 p-4 rounded-lg hover:bg-white disabled:bg-gray-500',
+  states: states,
+);
+
+WFlexContainer(
+  className: parsed,
+  children: [
+    WText('Submit', className: 'text-white'),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Prefix a utility with a state name and pass the active states to `classNameParser`. When a state is active, its prefix is stripped and the underlying utility applies; when it is not active, the prefixed token is removed:
+
+```dart
+final String parsed = classNameParser(
+  'bg-primary-500 hover:bg-white disabled:bg-gray-500',
+  states: ['hover'],
+);
+// hover active -> bg-white wins; disabled token dropped.
+```
+
+State names are not a fixed set. Any token you list in `states` matches the corresponding prefix, so `hover`, `disabled`, `pressed`, `selected`, or your own custom name all work the same way.
+
+<a name="how-it-works"></a>
+## How It Works
+
+`classNameParser(className, {states})` walks the `className` and, for each active state, strips the matching `state:` prefix so the utility behind it is applied. Prefixed tokens whose state is not active are dropped before the parsers run.
+
+This is why state-based styling needs a stateful host widget: your widget decides which states are active (a hover from an `InkWell`, a `disabled` flag, a selection), assembles them into a list, and feeds that list to `classNameParser`. Wind does not track widget state for you; it resolves the class names against the states you report.
+
+<a name="building-a-stateful-widget"></a>
+## Building a Stateful Widget
+
+Here is a reusable button that tracks hover and disabled states and styles itself through `classNameParser`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+class AppButton extends StatefulWidget {
+  final String? className;
+  final String? textClassName;
+  final String? text;
+  final bool disabled;
+
+  const AppButton({
+    super.key,
+    this.className,
+    this.textClassName,
+    this.text,
+    this.disabled = false,
+  });
+
+  @override
+  State<AppButton> createState() => _AppButtonState();
+}
+
+class _AppButtonState extends State<AppButton> {
+  bool isHovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<String> states = [];
+    if (widget.disabled) states.add('disabled');
+    if (isHovered) states.add('hover');
+
+    final String parsedClassName = classNameParser(widget.className, states: states);
+    final String parsedTextClassName = classNameParser(widget.textClassName, states: states);
+
+    return InkWell(
+      onHover: (hovered) {
+        if (!widget.disabled) {
+          setState(() => isHovered = hovered);
+        }
+      },
+      onTap: widget.disabled ? null : () {},
+      child: WFlexContainer(
+        className: parsedClassName,
+        children: [
+          WText(widget.text ?? 'Button', className: parsedTextClassName),
+        ],
+      ),
+    );
+  }
+}
+```
+
+Used like this, the prefixed utilities resolve as the button's state changes:
+
+```dart
+AppButton(
+  className: 'bg-primary-500 p-4 rounded-lg hover:bg-white',
+  textClassName: 'text-white hover:text-primary-600',
+  text: 'Submit',
+);
+```
+
+<a name="best-practices"></a>
+## Best Practices
+
+- Drive states from your widget's own logic (hover callbacks, flags) and pass them into `classNameParser`; Wind does not manage state for you.
+- Parse every class string that should react to state, including separate text class names, with the same `states` list.
+- Keep base styles unprefixed and add only the state-specific overrides behind a prefix.
+- Reuse one stateful wrapper (like `AppButton`) across your app instead of wiring state tracking into every call site.
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Dark Mode](dark-mode.md) — the `dark:` prefix, resolved separately from interaction states.
+- [Responsive Design](responsive-design.md) — breakpoint prefixes that compose with utilities.
+- [Background Color](../backgrounds/background-color.md) — the `bg-*` utilities commonly toggled per state.
+- [Text Color](../typography/text-color.md) — the `text-*` utilities for state-driven text styling.

--- a/doc/concepts/utility-first.md
+++ b/doc/concepts/utility-first.md
@@ -1,0 +1,142 @@
+# Utility-First
+
+Utility-first is a design methodology built on small, single-purpose classes that compose into complex designs. Wind brings this approach to Flutter: instead of writing custom styles for every component, you build interfaces directly from utility classes in a `className`.
+
+- [Basic Usage](#basic-usage)
+- [The Flutter Way](#the-flutter-way)
+- [The Wind Way](#the-wind-way)
+- [Why Utility-First](#why-utility-first)
+- [Best Practices](#best-practices)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="core/utility_first_wind" size="lg" source="example/lib/pages/core/utility_first_wind.dart"></x-preview>
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+class UtilityFirstWind extends StatelessWidget {
+  const UtilityFirstWind({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WCard(
+      className: 'shadow-lg rounded-lg m-4 p-4 bg-black',
+      child: WFlex(
+        className: 'flex-col axis-min gap-2 items-start',
+        children: [
+          WText('12', className: 'text-4xl leading-6 font-bold text-white'),
+          WText('Active users on the website', className: 'text-white leading-4'),
+          WText(
+            'Composed entirely from utility classes.',
+            className: 'text-gray-300 text-xs',
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Every visual decision is expressed as a utility class in `className`. Spacing, color, typography, and radius all live in one place, so you read the styling without jumping between widget constructors:
+
+```dart
+WCard(
+  className: 'shadow-lg rounded-lg p-4 bg-black',
+  child: WText('Styled in one line.', className: 'text-white text-lg font-bold'),
+);
+```
+
+<a name="the-flutter-way"></a>
+## The Flutter Way
+
+Plain Flutter spreads styling across nested constructors and `TextStyle` objects. The same card requires explicit `Card`, `Padding`, `Column`, and per-`Text` styles:
+
+<x-preview path="core/utility_first_flutter" size="md" source="example/lib/pages/core/utility_first_flutter.dart"></x-preview>
+
+```dart
+import 'package:flutter/material.dart';
+
+class UtilityFirstFlutter extends StatelessWidget {
+  const UtilityFirstFlutter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.all(16),
+      color: Colors.black,
+      elevation: 8,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              '12',
+              style: TextStyle(
+                fontSize: 36,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'Active users on the website',
+              style: TextStyle(fontSize: 14, color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+<a name="the-wind-way"></a>
+## The Wind Way
+
+Wind collapses that structure into utility classes on Wind widgets. The intent reads in a single glance and stays consistent because the same tokens map to the same theme values everywhere:
+
+```dart
+WCard(
+  className: 'shadow-lg rounded-lg m-4 p-4 bg-black',
+  child: WFlex(
+    className: 'flex-col axis-min gap-2 items-start',
+    children: [
+      WText('12', className: 'text-4xl leading-6 font-bold text-white'),
+      WText('Active users on the website', className: 'text-white leading-4'),
+    ],
+  ),
+);
+```
+
+<a name="why-utility-first"></a>
+## Why Utility-First
+
+- **Consistency.** Tokens resolve to theme values (`bg-black`, `text-4xl`, `rounded-lg`), so every screen pulls from the same scale instead of one-off magic numbers.
+- **Speed.** You style in place without defining a custom widget or `TextStyle` for each variation.
+- **Readability.** The full visual definition lives on one line next to the structure it styles.
+- **Adaptivity.** The same tokens compose with `dark:`, breakpoint, and state prefixes, so one class string covers multiple contexts.
+
+<a name="best-practices"></a>
+## Best Practices
+
+- Reach for utility classes first; extract a custom widget only when a composition repeats across the app.
+- Group related tokens in a readable order (layout, spacing, color, typography) inside the `className`.
+- Lean on theme tokens (`bg-gray-200`, `text-lg`) over arbitrary values so dark-mode inversion and theming stay coherent.
+- Pair color tokens with their `dark:` counterparts where a value should not rely on automatic inversion.
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Dark Mode](dark-mode.md) — how utility colors invert automatically.
+- [Responsive Design](responsive-design.md) — composing utilities with breakpoint prefixes.
+- [State-Based Styling](state-based-styling.md) — utilities that react to widget state.
+- [WCard](../widgets/wcard.md) — the card widget used in these examples.

--- a/doc/customization/colors.md
+++ b/doc/customization/colors.md
@@ -1,0 +1,162 @@
+# Customizing Colors
+
+The `WindTheme` class ships a TailwindCSS-inspired color palette and lets you read, extend, and override colors through static helpers.
+
+- [Color Palette](#color-palette)
+- [Using Colors](#using-colors)
+- [Customizing the Palette](#customizing-the-palette)
+- [Working with Colors Programmatically](#working-with-colors-programmatically)
+- [Related Documentation](#related-documentation)
+
+```dart
+WCard(
+  className: 'bg-gray-100 dark:bg-gray-800 rounded-lg items-center justify-center',
+  child: WText(
+    'Wind colors at a glance.',
+    className: 'text-gray-900 dark:text-white',
+  ),
+);
+```
+
+<a name="color-palette"></a>
+## Color Palette
+
+The default palette in `WindTheme` includes color families such as `slate`, `gray`, `red`, and `indigo`. Each color is a `MaterialColor` supporting shades from 50 (lightest) to 900 (darkest). The default shade is 500, used when no specific shade is provided (e.g. `bg-indigo` resolves to indigo 500).
+
+| Name | Token |
+|:---|:---|
+| `slate` | `bg-slate-500` |
+| `gray` | `bg-gray-500` |
+| `zinc` | `bg-zinc-500` |
+| `neutral` | `bg-neutral-500` |
+| `stone` | `bg-stone-500` |
+| `red` | `bg-red-500` |
+| `orange` | `bg-orange-500` |
+| `amber` | `bg-amber-500` |
+| `yellow` | `bg-yellow-500` |
+| `lime` | `bg-lime-500` |
+| `green` | `bg-green-500` |
+| `emerald` | `bg-emerald-500` |
+| `teal` | `bg-teal-500` |
+| `cyan` | `bg-cyan-500` |
+| `sky` | `bg-sky-500` |
+| `blue` | `bg-blue-500` |
+| `indigo` | `bg-indigo-500` |
+| `violet` | `bg-violet-500` |
+| `purple` | `bg-purple-500` |
+| `fuchsia` | `bg-fuchsia-500` |
+| `pink` | `bg-pink-500` |
+| `black` | `bg-black` |
+| `white` | `bg-white` |
+
+`primary` (mapped to `indigo`) and `secondary` (mapped to `slate`) are also registered as palette aliases.
+
+<a name="using-colors"></a>
+## Using Colors
+
+Palette colors can be used in utility classes or read programmatically.
+
+### Utility Classes
+
+```dart
+WCard(
+  className: 'bg-gray-100 dark:bg-gray-800 rounded-lg items-center justify-center',
+  child: WText(
+    'Full width at small screens.',
+    className: 'text-black dark:text-white',
+  ),
+);
+```
+
+In this example:
+
+- `bg-gray-100` sets the background to the 100 shade of gray.
+- `text-black` sets the text color to black.
+
+### The `wColor` Helper
+
+`wColor` retrieves a color from the palette. If no shade is specified, shade 500 is used. The name may carry an inline shade (`gray-100`) or pass `shade:` explicitly. Under `Brightness.dark`, the optional `darkName` / `darkShade` parameters override the resolved color.
+
+```dart
+return Scaffold(
+  backgroundColor: wColor('gray-100'), // Background set to gray-100
+  body: Center(
+    child: Text(
+      'Hello, Wind!',
+      style: TextStyle(color: wColor('indigo')), // Defaults to indigo-500
+    ),
+  ),
+);
+```
+
+<a name="customizing-the-palette"></a>
+## Customizing the Palette
+
+Register a custom color with `WindTheme.addColor`.
+
+### 1. Define your `MaterialColor`
+
+```dart
+MaterialColor customColor = MaterialColor(0xff123456, {
+  50: Color(0xffe3e3e3),
+  100: Color(0xffd1d1d1),
+  200: Color(0xffb3b3b3),
+  300: Color(0xff949494),
+  400: Color(0xff767676),
+  500: Color(0xff123456), // Primary shade
+  600: Color(0xff0e2e42),
+  700: Color(0xff091b2c),
+  800: Color(0xff050c16),
+  900: Color(0xff000000),
+});
+```
+
+### 2. Add the color to the palette
+
+```dart
+WindTheme.addColor('custom', customColor);
+```
+
+### 3. Use your custom color
+
+```dart
+// Utility class
+WText('Hello, Wind!', className: 'text-custom-500');
+```
+
+```dart
+// wColor helper
+Color myCustomShade = wColor('custom-500');
+```
+
+<a name="working-with-colors-programmatically"></a>
+## Working with Colors Programmatically
+
+`WindTheme` exposes helpers for reading the palette at runtime.
+
+```dart
+// Retrieve a MaterialColor by name
+MaterialColor indigo = WindTheme.getMaterialColor('indigo');
+```
+
+```dart
+// Retrieve a specific shade. Defaults to 500 when no shade is provided.
+Color indigoShade = WindTheme.getColor('indigo', shade: 300);
+```
+
+```dart
+// Check whether a color exists in the palette
+bool exists = WindTheme.isValidColor('indigo'); // true
+bool notExists = WindTheme.isValidColor('random'); // false
+```
+
+```dart
+// Retrieve every color in the palette
+Map<String, MaterialColor> allColors = WindTheme.getColors();
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Background Color](../backgrounds/background-color.md) — apply palette colors to surfaces
+- [Text Color](../typography/text-color.md) — apply palette colors to text
+- [Dark Mode](../concepts/dark-mode.md) — automatic color inversion with the `dark:` prefix

--- a/doc/customization/font-family.md
+++ b/doc/customization/font-family.md
@@ -1,0 +1,79 @@
+# Font Family Customization
+
+Customize the body and display fonts of your application through `WindTheme`, backed by the Google Fonts library.
+
+- [Default Font](#default-font)
+- [Customizing Fonts](#customizing-fonts)
+- [Binding Fonts to the Flutter Theme](#binding-fonts-to-the-flutter-theme)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setBodyFontString('Roboto');
+WindTheme.setDisplayFontString('Lobster');
+```
+
+<a name="default-font"></a>
+## Default Font
+
+When you start a new application with wind, the default font family is **Inter**, a versatile sans-serif face. You can replace it with any font supported by Google Fonts to match your design.
+
+<a name="customizing-fonts"></a>
+## Customizing Fonts
+
+`WindTheme` configures two fonts: the body font for general text content and the display font for large, prominent text such as headings.
+
+### Body Font
+
+The body font is the primary font used for general text content.
+
+```dart
+// Set the body font
+WindTheme.setBodyFontString('Roboto');
+```
+
+After this call, all text styled with the body font defaults to **Roboto**.
+
+```dart
+// Retrieve the current body font
+String currentBodyFont = WindTheme.getBodyFontString();
+print('Current body font: $currentBodyFont'); // Output: 'Roboto'
+```
+
+### Display Font
+
+The display font is typically used for large, prominent text such as headings or titles.
+
+```dart
+// Set the display font
+WindTheme.setDisplayFontString('Lobster');
+```
+
+If no display font is set, `getDisplayFontString` falls back to the body font.
+
+```dart
+// Retrieve the current display font
+String currentDisplayFont = WindTheme.getDisplayFontString();
+print('Current display font: $currentDisplayFont'); // Output: 'Lobster'
+```
+
+<a name="binding-fonts-to-the-flutter-theme"></a>
+## Binding Fonts to the Flutter Theme
+
+To apply the configured fonts globally, bind them to Flutter's `ThemeData` through `WindTheme.toThemeData`, which integrates the font settings with Flutter's theme system. You can also pass `bodyFontString` and `displayFontString` directly to `toThemeData` to override the configured fonts for a single build.
+
+```dart
+MaterialApp(
+  theme: WindTheme.toThemeData(
+    bodyFontString: 'Roboto',
+    displayFontString: 'Lobster',
+  ),
+);
+```
+
+For full guidance on applying fonts at the theme level, see [Binding the Flutter Theme](../getting-started/binding-the-flutter-theme.md).
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Binding the Flutter Theme](../getting-started/binding-the-flutter-theme.md) — apply fonts at the theme level
+- [Font Size](./font-size.md) — customize the typographic scale
+- [Font Weight](./font-weight.md) — customize weight keys

--- a/doc/customization/font-size.md
+++ b/doc/customization/font-size.md
@@ -1,0 +1,80 @@
+# Customizing Font Sizes
+
+Manage the typographic scale through `WindTheme`: pre-defined sizes, arbitrary values, and programmatic customization.
+
+- [Default Font Sizes](#default-font-sizes)
+- [Arbitrary Font Sizes](#arbitrary-font-sizes)
+- [Managing Font Sizes](#managing-font-sizes)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setFontSize('custom', 1.2);
+double size = WindTheme.getFontSize('xl'); // 1.25
+```
+
+<a name="default-font-sizes"></a>
+## Default Font Sizes
+
+`WindTheme` ships a set of pre-defined font sizes. Sizes are stored in rem units and scaled by the rem factor (pixel factor × 4 = 16 by default).
+
+| Key | Value (rem) | Calculated px (rem factor 16) | Description |
+|:---|:---|:---|:---|
+| `xs` | `0.75` | `12px` | Extra small |
+| `sm` | `0.875` | `14px` | Small |
+| `base` | `1` | `16px` | Base size |
+| `lg` | `1.125` | `18px` | Large |
+| `xl` | `1.25` | `20px` | Extra large |
+| `2xl` | `1.5` | `24px` | Very large |
+| `3xl` | `1.875` | `30px` | Extra extra large |
+| `4xl` | `2.25` | `36px` | Huge |
+| `5xl` | `3` | `48px` | Massive |
+| `6xl` | `4` | `64px` | Gigantic |
+
+For example:
+
+- `font-xs` applies a font size of **12px**.
+- `font-3xl` applies a font size of **30px**.
+
+<a name="arbitrary-font-sizes"></a>
+## Arbitrary Font Sizes
+
+For sizes outside the scale, use the `font-[value]` syntax, where value is the desired size in px.
+
+- `font-[8]` applies a font size of **8px**.
+- `font-[22]` applies a font size of **22px**.
+
+<a name="managing-font-sizes"></a>
+## Managing Font Sizes
+
+`WindTheme` provides methods to check, retrieve, add, and remove font sizes at runtime.
+
+```dart
+// Check whether a font size exists
+bool exists = WindTheme.hasFontSize('lg');
+print(exists); // Output: true
+```
+
+```dart
+// Retrieve a font size value
+double size = WindTheme.getFontSize('xl');
+print(size); // Output: 1.25
+```
+
+```dart
+// Add a custom font size
+WindTheme.setFontSize('custom', 1.2);
+
+// Update an existing font size
+WindTheme.setFontSize('lg', 1.0);
+```
+
+```dart
+// Remove a font size
+WindTheme.removeFontSize('custom');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Font Size Utilities](../typography/font-size.md) — apply the scale with `font-*`
+- [Pixel Factor](./pixel-factor.md) — how the rem factor scales sizes
+- [Font Family](./font-family.md) — customize the body and display fonts

--- a/doc/customization/font-size.md
+++ b/doc/customization/font-size.md
@@ -12,6 +12,8 @@ WindTheme.setFontSize('custom', 1.2);
 double size = WindTheme.getFontSize('xl'); // 1.25
 ```
 
+Font sizes are applied with the `text-*` utility (e.g. `text-xl`); the `font-*` prefix is reserved for [font weight](./font-weight.md).
+
 <a name="default-font-sizes"></a>
 ## Default Font Sizes
 
@@ -32,16 +34,16 @@ double size = WindTheme.getFontSize('xl'); // 1.25
 
 For example:
 
-- `font-xs` applies a font size of **12px**.
-- `font-3xl` applies a font size of **30px**.
+- `text-xs` applies a font size of **12px**.
+- `text-3xl` applies a font size of **30px**.
 
 <a name="arbitrary-font-sizes"></a>
 ## Arbitrary Font Sizes
 
-For sizes outside the scale, use the `font-[value]` syntax, where value is the desired size in px.
+For sizes outside the scale, use the `text-[value]` syntax, where value is the desired size in px.
 
-- `font-[8]` applies a font size of **8px**.
-- `font-[22]` applies a font size of **22px**.
+- `text-[8]` applies a font size of **8px**.
+- `text-[22]` applies a font size of **22px**.
 
 <a name="managing-font-sizes"></a>
 ## Managing Font Sizes
@@ -75,6 +77,6 @@ WindTheme.removeFontSize('custom');
 
 <a name="related-documentation"></a>
 ## Related Documentation
-- [Font Size Utilities](../typography/font-size.md) — apply the scale with `font-*`
+- [Font Size Utilities](../typography/font-size.md) — apply the scale with `text-*`
 - [Pixel Factor](./pixel-factor.md) — how the rem factor scales sizes
 - [Font Family](./font-family.md) — customize the body and display fonts

--- a/doc/customization/font-weight.md
+++ b/doc/customization/font-weight.md
@@ -1,0 +1,70 @@
+# Customizing Font Weight
+
+Manage font weights through `WindTheme`: pre-defined keys mapped to Flutter `FontWeight` values, customizable at runtime.
+
+- [Default Font Weights](#default-font-weights)
+- [Managing Font Weights](#managing-font-weights)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setFontWeight('ultrabold', FontWeight.w800);
+FontWeight weight = WindTheme.getFontWeight('medium'); // FontWeight.w500
+```
+
+<a name="default-font-weights"></a>
+## Default Font Weights
+
+`WindTheme` ships pre-defined font weights mapped to intuitive keys. Each key corresponds to a Flutter `FontWeight` value.
+
+| Key | FontWeight | Description |
+|:---|:---|:---|
+| `thin` | `w100` | Thinnest weight |
+| `extralight` | `w200` | Extra light weight |
+| `light` | `w300` | Light weight |
+| `normal` | `w400` | Regular weight |
+| `medium` | `w500` | Medium weight |
+| `semibold` | `w600` | Semi-bold weight |
+| `bold` | `w700` | Bold weight |
+| `extrabold` | `w800` | Extra bold weight |
+| `black` | `w900` | Heaviest weight |
+
+For example:
+
+- `font-thin` applies the thinnest weight (`w100`).
+- `font-bold` applies a bold weight (`w700`).
+
+<a name="managing-font-weights"></a>
+## Managing Font Weights
+
+`WindTheme` provides methods to check, retrieve, customize, and remove font weights at runtime.
+
+```dart
+// Check whether a font weight exists
+bool exists = WindTheme.hasFontWeight('bold');
+print(exists); // Output: true
+```
+
+```dart
+// Retrieve a font weight value
+FontWeight weight = WindTheme.getFontWeight('medium');
+print(weight); // Output: FontWeight.w500
+```
+
+```dart
+// Add a custom font weight
+WindTheme.setFontWeight('ultrabold', FontWeight.w800);
+
+// Update an existing font weight
+WindTheme.setFontWeight('bold', FontWeight.w600);
+```
+
+```dart
+// Remove a font weight
+WindTheme.removeFontWeight('extralight');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Font Weight Utilities](../typography/font-weight.md) — apply weights with `font-*`
+- [Font Family](./font-family.md) — customize the body and display fonts
+- [Font Size](./font-size.md) — customize the typographic scale

--- a/doc/customization/letter-spacing.md
+++ b/doc/customization/letter-spacing.md
@@ -1,0 +1,76 @@
+# Customizing Letter Spacing
+
+Manage character spacing through `WindTheme`: pre-defined keys, arbitrary values, and runtime customization.
+
+- [Default Letter Spacings](#default-letter-spacings)
+- [Arbitrary Letter Spacings](#arbitrary-letter-spacings)
+- [Managing Letter Spacings](#managing-letter-spacings)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setLetterSpacing('extra-wide', 0.15);
+double spacing = WindTheme.getLetterSpacing('wide'); // 0.025
+```
+
+<a name="default-letter-spacings"></a>
+## Default Letter Spacings
+
+`WindTheme` defines several pre-defined letter spacings mapped to descriptive keys. Values are in em units.
+
+| Key | Value (em) | Description |
+|:---|:---|:---|
+| `tighter` | `-0.05` | Very tight spacing |
+| `tight` | `-0.025` | Tight spacing |
+| `normal` | `0` | Default spacing |
+| `wide` | `0.025` | Wide spacing |
+| `wider` | `0.05` | Very wide spacing |
+| `widest` | `0.1` | Extremely wide spacing |
+
+For example:
+
+- `tracking-tight` applies a letter spacing of **-0.025em**.
+- `tracking-wide` applies a letter spacing of **0.025em**.
+
+<a name="arbitrary-letter-spacings"></a>
+## Arbitrary Letter Spacings
+
+For values outside the scale, use the `tracking-[value]` syntax, where value is the desired spacing in em units.
+
+- `tracking-[0.1]` applies a letter spacing of **0.1em**.
+- `tracking-[0.3]` applies a letter spacing of **0.3em**.
+
+<a name="managing-letter-spacings"></a>
+## Managing Letter Spacings
+
+`WindTheme` provides methods to check, retrieve, add, and remove letter spacings at runtime.
+
+```dart
+// Check whether a letter spacing exists
+bool exists = WindTheme.hasLetterSpacing('normal');
+print(exists); // Output: true
+```
+
+```dart
+// Retrieve a letter spacing value
+double spacing = WindTheme.getLetterSpacing('wide');
+print(spacing); // Output: 0.025
+```
+
+```dart
+// Add a custom letter spacing
+WindTheme.setLetterSpacing('extra-wide', 0.15);
+
+// Update an existing letter spacing
+WindTheme.setLetterSpacing('wide', 0.03);
+```
+
+```dart
+// Remove a letter spacing
+WindTheme.removeLetterSpacing('extra-wide');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Letter Spacing Utilities](../typography/letter-spacing.md) — apply spacing with `tracking-*`
+- [Line Height](./line-height.md) — customize line height keys
+- [Font Size](./font-size.md) — customize the typographic scale

--- a/doc/customization/line-height.md
+++ b/doc/customization/line-height.md
@@ -1,0 +1,84 @@
+# Customizing Line Height
+
+Manage line heights through `WindTheme`: pre-defined keys, arbitrary values, and runtime customization.
+
+- [Default Line Heights](#default-line-heights)
+- [Arbitrary Line Heights](#arbitrary-line-heights)
+- [Managing Line Heights](#managing-line-heights)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setLineHeight('custom', 1.2);
+double height = WindTheme.getLineHeight('tight'); // 1.25
+```
+
+<a name="default-line-heights"></a>
+## Default Line Heights
+
+`WindTheme` includes several pre-defined line heights mapped to intuitive keys. Values are multipliers applied to the font size.
+
+| Key | Value | Description |
+|:---|:---|:---|
+| `3` | `0.75` | Compact line height |
+| `4` | `1` | Standard compact |
+| `5` | `1.25` | Slightly expanded |
+| `6` | `1.5` | Comfortable |
+| `7` | `1.75` | Spacious |
+| `8` | `2` | Very spacious |
+| `9` | `2.25` | Extra spacious |
+| `10` | `2.5` | Maximum spaciousness |
+| `none` | `1` | No additional spacing |
+| `tight` | `1.25` | Tight spacing |
+| `snug` | `1.375` | Snug spacing |
+| `normal` | `1.5` | Normal spacing |
+| `relaxed` | `1.625` | Relaxed spacing |
+| `loose` | `2` | Loose spacing |
+
+For example:
+
+- `leading-3` applies a line height of **0.75**.
+- `leading-8` applies a line height of **2**.
+
+<a name="arbitrary-line-heights"></a>
+## Arbitrary Line Heights
+
+For values outside the scale, use the `leading-[value]` syntax, where value is the desired multiplier.
+
+- `leading-[1.2]` applies a line height of **1.2**.
+- `leading-[2.8]` applies a line height of **2.8**.
+
+<a name="managing-line-heights"></a>
+## Managing Line Heights
+
+`WindTheme` provides methods to check, retrieve, add, and remove line heights at runtime.
+
+```dart
+// Check whether a line height exists
+bool exists = WindTheme.hasLineHeight('normal');
+print(exists); // Output: true
+```
+
+```dart
+// Retrieve a line height value
+double height = WindTheme.getLineHeight('tight');
+print(height); // Output: 1.25
+```
+
+```dart
+// Add a custom line height
+WindTheme.setLineHeight('custom', 1.2);
+
+// Update an existing line height
+WindTheme.setLineHeight('snug', 1.4);
+```
+
+```dart
+// Remove a line height
+WindTheme.removeLineHeight('custom');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Line Height Utilities](../typography/line-height.md) — apply heights with `leading-*`
+- [Letter Spacing](./letter-spacing.md) — customize character spacing
+- [Font Size](./font-size.md) — customize the typographic scale

--- a/doc/customization/pixel-factor.md
+++ b/doc/customization/pixel-factor.md
@@ -1,0 +1,71 @@
+# Pixel Factor Customization
+
+The pixel factor emulates the CSS rem unit, providing a single multiplier that scales all size-related values across your application.
+
+- [What is Pixel Factor](#what-is-pixel-factor)
+- [How Pixel Factor Works](#how-pixel-factor-works)
+- [Managing Pixel Factor](#managing-pixel-factor)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setPixelFactor(6.0);
+double factor = WindTheme.getPixelFactor(); // 6.0
+double rem = WindTheme.getRemFactor(); // pixelFactor * 4 = 24.0
+```
+
+<a name="what-is-pixel-factor"></a>
+## What is Pixel Factor
+
+Like the CSS rem unit, the pixel factor acts as a base unit multiplier. Size values (font sizes, spacing, padding) are calculated relative to this factor, enabling consistent scaling across resolutions.
+
+**Default value:** the pixel factor is `4.0`.
+
+<a name="how-pixel-factor-works"></a>
+## How Pixel Factor Works
+
+The rem factor is derived by multiplying the pixel factor by 4 (`getRemFactor` returns `pixelFactor * 4`). This relationship gives a predictable scaling system.
+
+### Example Calculation
+
+With the default pixel factor of `4.0`:
+
+```text
+1 rem = 4.0 * 4 = 16.0
+```
+
+A `2xl` font size with a multiplier of `1.5` therefore calculates to:
+
+```text
+1.5 (font size) * 4.0 (pixel factor) * 4 = 24.0
+```
+
+<a name="managing-pixel-factor"></a>
+## Managing Pixel Factor
+
+`WindTheme` exposes methods to read and set the pixel factor and to compute the derived rem factor.
+
+```dart
+// Retrieve the current pixel factor
+double currentFactor = WindTheme.getPixelFactor();
+print('Current pixel factor: $currentFactor'); // Output: 4.0 (default)
+```
+
+```dart
+// Retrieve the derived rem factor (pixelFactor * 4)
+double rem = WindTheme.getRemFactor();
+print('Current rem factor: $rem'); // Output: 16.0 (default)
+```
+
+```dart
+// Set a custom pixel factor
+WindTheme.setPixelFactor(6.0);
+print(WindTheme.getPixelFactor()); // Output: 6.0
+```
+
+Setting a new pixel factor scales all size-related values proportionally.
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Font Size](./font-size.md) — sizes scale by the rem factor
+- [Rounded Corners](./rounded-corners.md) — radii scale by the rem factor
+- [Spacing: Padding](../spacing/padding.md) — padding values scale by the rem factor

--- a/doc/customization/rounded-corners.md
+++ b/doc/customization/rounded-corners.md
@@ -1,0 +1,124 @@
+# Customizing Rounded Corners
+
+Manage corner radii through `WindTheme`: pre-defined sizes, arbitrary values, and runtime customization.
+
+- [Default Rounded Sizes](#default-rounded-sizes)
+- [Arbitrary Rounded Values](#arbitrary-rounded-values)
+- [Managing Rounded Sizes](#managing-rounded-sizes)
+- [Practical Examples](#practical-examples)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setRoundedSize('custom', 1.25);
+double size = WindTheme.getRoundedSize('xl'); // 0.75
+```
+
+<a name="default-rounded-sizes"></a>
+## Default Rounded Sizes
+
+`WindTheme` ships pre-defined rounded sizes. Each value is in rem units; the calculated px values below assume the default pixel factor (4.0) and rem factor (4.0).
+
+| Key | Value (rem) | Calculated px | Description |
+|:---|:---|:---|:---|
+| `none` | `0` | `0px` | No rounding |
+| `default` | `0.25` | `4px` | Default rounding |
+| `sm` | `0.125` | `2px` | Small rounding |
+| `md` | `0.375` | `6px` | Medium rounding |
+| `lg` | `0.5` | `8px` | Large rounding |
+| `xl` | `0.75` | `12px` | Extra large rounding |
+| `2xl` | `1` | `16px` | Very large rounding |
+| `3xl` | `1.5` | `24px` | Extra extra large |
+| `full` | `9999` | Infinite | Fully rounded corners |
+
+The px values are calculated as:
+
+```text
+{px} = {rem} * {pixel factor (4.0)} * {rem factor (4.0)}
+```
+
+For example, `rounded-lg` results in **0.5 × 4 × 4 = 8px**.
+
+<a name="arbitrary-rounded-values"></a>
+## Arbitrary Rounded Values
+
+For radii outside the scale, use the `rounded-[value]` syntax, where value is the desired radius in px.
+
+- `rounded-[7]` applies a radius of **7px**.
+- `rounded-[20]` applies a radius of **20px**.
+
+<a name="managing-rounded-sizes"></a>
+## Managing Rounded Sizes
+
+`WindTheme` provides methods to check, retrieve, customize, and remove rounded sizes at runtime.
+
+```dart
+// Check whether a rounded size exists
+bool exists = WindTheme.hasRoundedSize('lg');
+print(exists); // Output: true
+```
+
+```dart
+// Retrieve a rounded size value (in rem)
+double size = WindTheme.getRoundedSize('xl');
+print(size); // Output: 0.75
+```
+
+```dart
+// Add a new size
+WindTheme.setRoundedSize('4xl', 2);
+
+// Update an existing size
+WindTheme.setRoundedSize('lg', 0.6);
+```
+
+```dart
+// Remove a rounded size
+WindTheme.removeRoundedSize('sm');
+```
+
+<a name="practical-examples"></a>
+## Practical Examples
+
+### Pre-defined Sizes
+
+```dart
+WContainer(
+  className: 'rounded-xl bg-gray-100 dark:bg-gray-800',
+  child: WText('Pre-defined rounded corners'),
+);
+```
+
+This applies a corner radius of **12px** (0.75 × 4 × 4).
+
+### Arbitrary Values
+
+```dart
+WContainer(
+  className: 'rounded-[15] bg-gray-200 dark:bg-gray-700',
+  child: WText('Arbitrary rounded corners'),
+);
+```
+
+This applies a corner radius of **15px**.
+
+### Custom Sizes
+
+```dart
+// Add a custom size
+WindTheme.setRoundedSize('custom', 1.25); // Adds 'rounded-custom'
+
+// Use the custom size
+WContainer(
+  className: 'rounded-custom bg-gray-300 dark:bg-gray-600',
+  child: WText('Custom rounded corners'),
+);
+
+// Remove the custom size
+WindTheme.removeRoundedSize('custom');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Border Radius](../borders/border-radius.md) — apply radii with `rounded-*`
+- [Pixel Factor](./pixel-factor.md) — how the rem factor scales sizes
+- [Shadows](./shadows.md) — customize shadow sizes

--- a/doc/customization/rounded-corners.md
+++ b/doc/customization/rounded-corners.md
@@ -16,7 +16,7 @@ double size = WindTheme.getRoundedSize('xl'); // 0.75
 <a name="default-rounded-sizes"></a>
 ## Default Rounded Sizes
 
-`WindTheme` ships pre-defined rounded sizes. Each value is in rem units; the calculated px values below assume the default pixel factor (4.0) and rem factor (4.0).
+`WindTheme` ships pre-defined rounded sizes. Each value is in rem units; the calculated px values below assume the default rem factor (`WindTheme.getRemFactor()`, which is pixel factor × 4 = 16).
 
 | Key | Value (rem) | Calculated px | Description |
 |:---|:---|:---|:---|
@@ -33,10 +33,10 @@ double size = WindTheme.getRoundedSize('xl'); // 0.75
 The px values are calculated as:
 
 ```text
-{px} = {rem} * {pixel factor (4.0)} * {rem factor (4.0)}
+{px} = {rem} × {rem factor (16 by default)}
 ```
 
-For example, `rounded-lg` results in **0.5 × 4 × 4 = 8px**.
+For example, `rounded-lg` results in **0.5 × 16 = 8px**.
 
 <a name="arbitrary-rounded-values"></a>
 ## Arbitrary Rounded Values
@@ -88,7 +88,7 @@ WContainer(
 );
 ```
 
-This applies a corner radius of **12px** (0.75 × 4 × 4).
+This applies a corner radius of **12px** (0.75 × 16).
 
 ### Arbitrary Values
 

--- a/doc/customization/shadows.md
+++ b/doc/customization/shadows.md
@@ -1,0 +1,79 @@
+# Customizing Shadows
+
+Manage shadow sizes through `WindTheme`: pre-defined keys, arbitrary values, and runtime customization.
+
+- [Default Shadow Sizes](#default-shadow-sizes)
+- [Arbitrary Shadow Values](#arbitrary-shadow-values)
+- [Managing Shadows](#managing-shadows)
+- [Related Documentation](#related-documentation)
+
+```dart
+WindTheme.setShadowSize('custom', 10);
+double size = WindTheme.getShadowSize('xl'); // 12
+```
+
+<a name="default-shadow-sizes"></a>
+## Default Shadow Sizes
+
+`WindTheme` includes default shadow sizes mapped to descriptive keys. Each value is an elevation in px.
+
+| Key | Value (px) | Description |
+|:---|:---|:---|
+| `none` | `0` | No shadow |
+| `sm` | `1` | Small shadow |
+| `default` | `2` | Default shadow size |
+| `md` | `4` | Medium shadow |
+| `lg` | `8` | Large shadow |
+| `xl` | `12` | Extra large shadow |
+| `2xl` | `16` | Very large shadow |
+| `3xl` | `24` | Extra extra large shadow |
+| `inner` | `1` | Inner shadow effect |
+
+For example:
+
+- `shadow-sm` applies a shadow with an elevation of **1px**.
+- `shadow-lg` applies a shadow with an elevation of **8px**.
+
+<a name="arbitrary-shadow-values"></a>
+## Arbitrary Shadow Values
+
+For sizes outside the scale, use the `shadow-[value]` syntax, where value is the desired elevation in px.
+
+- `shadow-[8]` applies a shadow with an elevation of **8px**.
+- `shadow-[20]` applies a shadow with an elevation of **20px**.
+
+<a name="managing-shadows"></a>
+## Managing Shadows
+
+`WindTheme` provides methods to check, retrieve, customize, and remove shadow sizes at runtime.
+
+```dart
+// Check whether a shadow size exists
+bool exists = WindTheme.hasShadowSize('lg');
+print(exists); // Output: true
+```
+
+```dart
+// Retrieve a shadow size value
+double size = WindTheme.getShadowSize('xl');
+print(size); // Output: 12
+```
+
+```dart
+// Add a custom shadow size
+WindTheme.setShadowSize('custom', 10);
+
+// Update an existing shadow size
+WindTheme.setShadowSize('lg', 6);
+```
+
+```dart
+// Remove a shadow size
+WindTheme.removeShadowSize('sm');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Shadow Utilities](../effects/shadow.md) — apply shadows with `shadow-*`
+- [Rounded Corners](./rounded-corners.md) — customize corner radii
+- [Colors](./colors.md) — the palette behind surface styling

--- a/doc/effects/shadow.md
+++ b/doc/effects/shadow.md
@@ -67,7 +67,7 @@ Using `shadow` without a size applies the `default` key (2px blur radius).
 Set any shadow blur radius with bracket notation. The value is used directly as pixels:
 
 ```text
-shadow-[[value]]
+shadow-[<value>]
 ```
 
 ```dart

--- a/doc/effects/shadow.md
+++ b/doc/effects/shadow.md
@@ -1,0 +1,120 @@
+# Shadow
+
+Apply shadow effects to widgets using predefined elevation keys or arbitrary pixel values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="effects/shadow" size="md" source="example/lib/pages/effects/shadow.dart"></x-preview>
+
+```dart
+WCard(
+  className: 'shadow-lg p-4 bg-white dark:bg-gray-800',
+  child: WText('Large Shadow', className: 'text-gray-700 dark:text-gray-200'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use the `shadow-` prefix followed by a size key to apply a box shadow:
+
+```dart
+WCard(
+  className: 'shadow p-4 bg-white dark:bg-gray-800',
+  child: WText('Default shadow', className: 'text-gray-900 dark:text-white'),
+)
+
+WCard(
+  className: 'shadow-xl p-4 bg-white dark:bg-gray-800',
+  child: WText('Extra large shadow', className: 'text-gray-900 dark:text-white'),
+)
+```
+
+Shadows are rendered as a `BoxShadow` with `color: Colors.black.withOpacity(0.1)`, the elevation as `blurRadius`, and `offset: Offset(0, elevation / 2)`.
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Syntax
+
+```text
+shadow-[size]
+shadow
+```
+
+Using `shadow` without a size applies the `default` key (2px blur radius).
+
+| Class | Blur Radius | Description |
+|:------|:-----------|:------------|
+| `shadow-none` | 0 | No shadow |
+| `shadow-sm` | 1 | Subtle shadow |
+| `shadow` | 2 | Default shadow |
+| `shadow-md` | 4 | Medium shadow |
+| `shadow-lg` | 8 | Large shadow |
+| `shadow-xl` | 12 | Extra large shadow |
+| `shadow-2xl` | 16 | Very large shadow |
+| `shadow-3xl` | 24 | Maximum shadow |
+| `shadow-inner` | 1 | Inner shadow (subtle) |
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Set any shadow blur radius with bracket notation. The value is used directly as pixels:
+
+```text
+shadow-[[value]]
+```
+
+```dart
+WCard(
+  className: 'shadow-[6] p-4 bg-white dark:bg-gray-800',
+  child: WText('Custom Shadow', className: 'text-gray-700 dark:text-gray-200'),
+)
+
+WCard(
+  className: 'shadow-[20] p-4 bg-white dark:bg-gray-800',
+  child: WText('Very large custom shadow'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Adjust shadow intensity at different breakpoints:
+
+```dart
+WCard(
+  className: 'shadow-sm md:shadow-lg lg:shadow-2xl p-4 bg-white dark:bg-gray-800',
+  child: WText('Responsive shadow'),
+)
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Override shadow keys or add new ones with `WindTheme.setShadowSize`:
+
+```dart
+// Override an existing key
+WindTheme.setShadowSize('lg', 10.0);
+// shadow-lg now uses 10px blur radius
+
+// Add a custom key
+WindTheme.setShadowSize('card', 6.0);
+WCard(className: 'shadow-card p-4 bg-white', child: WText('Card shadow'))
+```
+
+See [Customizing Shadows](../customization/shadows.md) for details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Customizing Shadows](../customization/shadows.md) — override the default shadow scale.
+- [Background Color](../backgrounds/background-color.md) — complement shadows with background colors.
+- [Border Radius](../borders/border-radius.md) — rounded corners pair well with shadows.
+- [Pixel Factor](../customization/pixel-factor.md) — how the pixel factor affects sizing calculations.

--- a/doc/example/product-grid.md
+++ b/doc/example/product-grid.md
@@ -1,0 +1,134 @@
+# Product Grid
+
+A responsive product collection grid that switches from a single-column layout on small screens
+to a multi-column row layout on medium screens and above.
+
+- [Overview](#overview)
+- [Code Walkthrough](#code-walkthrough)
+- [Key Patterns](#key-patterns)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="example/product_grid" size="lg" source="example/lib/pages/example/product_grid.dart"></x-preview>
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+class ProductGrid extends StatelessWidget {
+  const ProductGrid({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: wColor('gray', shade: 200),
+      body: WFlexContainer(
+        className: 'flex-col md:flex-row gap-4 p-4',
+        children: [
+          collectionCard(
+            imageUrl: 'https://picsum.photos/400/300',
+            title: 'Desk and Office',
+            description: 'Work from home accessories',
+          ),
+          collectionCard(
+            imageUrl: 'https://picsum.photos/400/300',
+            title: 'Self-Improvement',
+            description: 'Journals and note-taking',
+          ),
+          collectionCard(
+            imageUrl: 'https://picsum.photos/400/300',
+            title: 'Travel',
+            description: 'Daily commute essentials',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget collectionCard({
+    required String imageUrl,
+    required String title,
+    required String description,
+  }) {
+    return WFlexContainer(
+      className: 'flex-1 flex-col gap-2',
+      children: [
+        WContainer(
+          className: 'rounded-lg bg-white',
+          child: Image.network(imageUrl, fit: BoxFit.cover),
+        ),
+        WText(title, className: 'text-base font-bold text-gray-900'),
+        WText(description, className: 'text-sm text-gray-500'),
+      ],
+    );
+  }
+}
+```
+
+<a name="overview"></a>
+## Overview
+
+This example builds a product collection grid using only Wind utility classes. The layout
+stacks cards vertically by default (`flex-col`) and switches to a horizontal row (`md:flex-row`)
+once the screen reaches the `md` breakpoint (768 px). No manual `MediaQuery` calls are needed.
+
+<a name="code-walkthrough"></a>
+## Code Walkthrough
+
+### Outer container
+
+```dart
+WFlexContainer(
+  className: 'flex-col md:flex-row gap-4 p-4',
+  ...
+)
+```
+
+- `flex-col` — stacks children vertically on small screens.
+- `md:flex-row` — switches to horizontal layout at 768 px and wider.
+- `gap-4` — uniform spacing between the three collection cards.
+- `p-4` — page padding on all sides.
+
+### Collection card
+
+```dart
+WFlexContainer(
+  className: 'flex-1 flex-col gap-2',
+  ...
+)
+```
+
+- `flex-1` — each card grows to fill an equal share of the available row space.
+- `flex-col` — stacks the image, title, and description vertically.
+- `gap-2` — tight spacing between card elements.
+
+### Image container
+
+```dart
+WContainer(
+  className: 'rounded-lg bg-white',
+  child: Image.network(imageUrl, fit: BoxFit.cover),
+)
+```
+
+- `rounded-lg` — applies the theme's large corner radius.
+- `bg-white` — white background for the image card.
+
+<a name="key-patterns"></a>
+## Key Patterns
+
+| Pattern | Classes used | Purpose |
+| :--- | :--- | :--- |
+| Responsive direction | `flex-col md:flex-row` | Single column on mobile, side-by-side on desktop |
+| Equal-width columns | `flex-1` | All cards share available space equally |
+| Consistent spacing | `gap-4`, `gap-2` | Uniform gutters without manual `SizedBox` |
+| Theme color via helper | `wColor('gray', shade: 200)` | Access theme color palette in Dart code |
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex Direction](../flex/flex-direction.md) — `flex-col` and `flex-row`
+- [Flex X](../flex/flex-x.md) — `flex-1` and proportional sizing
+- [Gap](../flex/gap.md) — spacing between flex children
+- [Responsive Design](../concepts/responsive-design.md) — breakpoint prefixes like `md:`
+- [WFlexContainer](../widgets/wflexcontainer.md) — the flex layout widget
+- [WContainer](../widgets/wcontainer.md) — the container widget used for the image card

--- a/doc/flex/align-items.md
+++ b/doc/flex/align-items.md
@@ -1,0 +1,72 @@
+# Align Items
+
+Control how children are positioned along the cross axis of a flex container using the `items-*` utilities.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/align_items" size="md" source="example/lib/pages/flex/align_items.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'flex-row items-center bg-gray-100 h-64',
+  children: [
+    WCard(className: 'bg-blue-500 h-16', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 h-16', child: WText('Card 2')),
+    WCard(className: 'bg-red-500 h-16', child: WText('Card 3')),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+The `items-*` utilities map directly to Flutter's `CrossAxisAlignment` values and are applied to any `WFlexContainer` or `WFlex`.
+
+```dart
+WFlexContainer(
+  className: 'flex-row items-start bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 h-12', child: WText('Short')),
+    WCard(className: 'bg-green-500 h-24', child: WText('Tall')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | CrossAxisAlignment | Description |
+|:------|:-------------------|:------------|
+| `items-start` | `CrossAxisAlignment.start` | Align children at the start of the cross axis |
+| `items-end` | `CrossAxisAlignment.end` | Align children at the end of the cross axis |
+| `items-center` | `CrossAxisAlignment.center` | Center children along the cross axis |
+| `items-baseline` | `CrossAxisAlignment.baseline` | Align children to their text baseline |
+| `items-stretch` | `CrossAxisAlignment.stretch` | Stretch children to fill the cross axis |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any `items-*` class with a breakpoint to change alignment at specific screen sizes.
+
+```dart
+WFlexContainer(
+  className: 'flex-row items-start md:items-center lg:items-end',
+  children: [
+    WCard(className: 'bg-blue-500 h-16', child: WText('A')),
+    WCard(className: 'bg-green-500 h-24', child: WText('B')),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex Direction](./flex-direction.md) — control whether children are laid out in a row or column.
+- [Justify Content](./justify-content.md) — control alignment along the main axis.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.
+- [WFlex](../widgets/wflex.md) — alternative flex container accepting a `className`.

--- a/doc/flex/alignment.md
+++ b/doc/flex/alignment.md
@@ -1,0 +1,94 @@
+# Alignment
+
+Position a widget within its container using the `alignment-*` utilities. These map directly to Flutter's `Alignment` constants and work on any `WContainer`.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Combining with Flex](#combining-with-flex)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/alignment" size="md" source="example/lib/pages/flex/alignment.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'alignment-center bg-gray-200 w-full h-full',
+  child: WText('Centered', className: 'text-black dark:text-white'),
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply an `alignment-*` class to a `WContainer` to position its child widget within the available space.
+
+```dart
+WContainer(
+  className: 'alignment-top-left bg-gray-200 w-full h-64',
+  child: WText('Top-Left', className: 'text-black dark:text-white'),
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Flutter Alignment | Description |
+|:------|:------------------|:------------|
+| `alignment-top-left` | `Alignment.topLeft` | Aligns to the top-left corner |
+| `alignment-top-center` | `Alignment.topCenter` | Aligns to the top-center |
+| `alignment-top-right` | `Alignment.topRight` | Aligns to the top-right corner |
+| `alignment-center-left` | `Alignment.centerLeft` | Aligns to the center-left edge |
+| `alignment-center` | `Alignment.center` | Centers both horizontally and vertically |
+| `alignment-center-right` | `Alignment.centerRight` | Aligns to the center-right edge |
+| `alignment-bottom-left` | `Alignment.bottomLeft` | Aligns to the bottom-left corner |
+| `alignment-bottom-center` | `Alignment.bottomCenter` | Aligns to the bottom-center |
+| `alignment-bottom-right` | `Alignment.bottomRight` | Aligns to the bottom-right corner |
+| `alignment-left` | `Alignment.centerLeft` | Alias for `alignment-center-left` |
+| `alignment-right` | `Alignment.centerRight` | Alias for `alignment-center-right` |
+
+<a name="combining-with-flex"></a>
+## Combining with Flex
+
+You can combine `alignment-*` with other flex and style utilities for complex layouts.
+
+```dart
+WFlexContainer(
+  className: 'flex-row justify-evenly items-center w-full h-64 bg-gray-100',
+  children: [
+    WContainer(
+      className: 'alignment-top-left bg-blue-500 w-32 h-32',
+      child: WText('Top-Left', className: 'text-white'),
+    ),
+    WContainer(
+      className: 'alignment-center bg-green-500 w-32 h-32',
+      child: WText('Center', className: 'text-white'),
+    ),
+    WContainer(
+      className: 'alignment-bottom-right bg-red-500 w-32 h-32',
+      child: WText('Bottom-Right', className: 'text-white'),
+    ),
+  ],
+);
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix `alignment-*` classes with a breakpoint to change alignment at different screen sizes.
+
+```dart
+WContainer(
+  className: 'alignment-top-left md:alignment-center bg-gray-200 w-full h-64',
+  child: WText('Responsive Alignment', className: 'text-black dark:text-white'),
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Align Items](./align-items.md) — control cross-axis alignment inside flex containers.
+- [Justify Content](./justify-content.md) — control main-axis alignment inside flex containers.
+- [WContainer](../widgets/wcontainer.md) — the container widget that alignment classes are applied to.
+- [Flex Direction](./flex-direction.md) — control the direction of flex layout.

--- a/doc/flex/axis-sizes.md
+++ b/doc/flex/axis-sizes.md
@@ -1,0 +1,68 @@
+# Axis Sizes
+
+Control how much space a flex container occupies along its main axis using `axis-max` and `axis-min`.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/axis_sizes" size="md" source="example/lib/pages/flex/axis_sizes.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'axis-max flex-row bg-gray-400',
+  children: [
+    WCard(className: 'bg-blue-500 w-20 h-20', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 w-20 h-20', child: WText('Card 2')),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`axis-max` makes the flex container stretch to fill all available space along the main axis. `axis-min` shrinks the container to fit its children exactly.
+
+```dart
+// Only occupies the space its children need
+WFlexContainer(
+  className: 'axis-min flex-row bg-gray-400',
+  children: [
+    WCard(className: 'bg-blue-500 w-20 h-20', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 w-20 h-20', child: WText('Card 2')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | MainAxisSize | Description |
+|:------|:-------------|:------------|
+| `axis-max` | `MainAxisSize.max` | Container takes up all available space along the main axis |
+| `axis-min` | `MainAxisSize.min` | Container takes up only the space required by its children |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix axis-size classes with a breakpoint to change behavior at specific screen widths.
+
+```dart
+WFlexContainer(
+  className: 'axis-min md:axis-max flex-row bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-20 h-20', child: WText('A')),
+    WCard(className: 'bg-green-500 w-20 h-20', child: WText('B')),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex Direction](./flex-direction.md) — control whether the main axis runs horizontally or vertically.
+- [Flex Fit](./flex-fit.md) — control how individual children are sized within the flex container.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.

--- a/doc/flex/flex-direction.md
+++ b/doc/flex/flex-direction.md
@@ -1,0 +1,72 @@
+# Flex Direction
+
+Set the layout direction of a flex container — horizontal row or vertical column — using `flex-row` and `flex-col`.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/flex_direction" size="md" source="example/lib/pages/flex/flex_direction.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'flex-row w-full h-40 bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-1/3 h-full', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 w-1/3 h-full', child: WText('Card 2')),
+    WCard(className: 'bg-red-500 w-1/3 h-full', child: WText('Card 3')),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use `flex-row` to lay out children horizontally and `flex-col` to lay them out vertically.
+
+```dart
+// Vertical stack
+WFlexContainer(
+  className: 'flex-col bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-full h-16', child: WText('Top')),
+    WCard(className: 'bg-green-500 w-full h-16', child: WText('Middle')),
+    WCard(className: 'bg-red-500 w-full h-16', child: WText('Bottom')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Axis | Description |
+|:------|:-----|:------------|
+| `flex-row` | `Axis.horizontal` | Lay out children left-to-right |
+| `flex-col` | `Axis.vertical` | Lay out children top-to-bottom |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Switch direction at different breakpoints by prefixing the class.
+
+```dart
+WFlexContainer(
+  className: 'flex-col md:flex-row bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 h-16', child: WText('A')),
+    WCard(className: 'bg-green-500 h-16', child: WText('B')),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Justify Content](./justify-content.md) — control main-axis alignment.
+- [Align Items](./align-items.md) — control cross-axis alignment.
+- [Axis Sizes](./axis-sizes.md) — control how much space the container occupies along its main axis.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.
+- [WFlex](../widgets/wflex.md) — alternative flex container.

--- a/doc/flex/flex-fit.md
+++ b/doc/flex/flex-fit.md
@@ -1,0 +1,88 @@
+# Flex Fit
+
+Control how a child widget sizes itself within a flex container using `flex-grow` and `flex-auto`.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/flex_fit" size="md" source="example/lib/pages/flex/flex_fit.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'flex-row bg-gray-100',
+  children: [
+    WCard(
+      className: 'flex-grow bg-blue-500',
+      child: WText('Grow'),
+    ),
+    WCard(
+      className: 'flex-auto bg-green-500',
+      child: WText('Auto'),
+    ),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`flex-grow` expands the child to fill all remaining space in the flex container (`FlexFit.tight`). `flex-auto` lets the child take only the space it needs (`FlexFit.loose`).
+
+```dart
+WFlexContainer(
+  className: 'flex-row bg-gray-100',
+  children: [
+    // Takes all remaining horizontal space
+    WCard(
+      className: 'flex-grow bg-blue-500',
+      child: WText('Fills remaining space'),
+    ),
+    // Sized to its content
+    WCard(
+      className: 'flex-auto bg-green-500',
+      child: WText('Content width'),
+    ),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | FlexFit | Description |
+|:------|:--------|:------------|
+| `flex-grow` | `FlexFit.tight` | Child expands to fill all available space |
+| `flex-auto` | `FlexFit.loose` | Child takes only the space it requires |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine flex-fit classes with breakpoint prefixes to change sizing behavior at different screen sizes.
+
+```dart
+WFlexContainer(
+  className: 'flex-row bg-gray-100',
+  children: [
+    WCard(
+      className: 'flex-auto md:flex-grow bg-blue-500',
+      child: WText('Adapts'),
+    ),
+    WCard(
+      className: 'flex-auto bg-green-500',
+      child: WText('Always auto'),
+    ),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex-x](./flex-x.md) — set a numeric flex factor (`flex-1`, `flex-2`, etc.).
+- [Axis Sizes](./axis-sizes.md) — control the container's main-axis size.
+- [WFlexible](../widgets/wflexible.md) — the widget that wraps the Flutter `Flexible` primitive.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.

--- a/doc/flex/flex-x.md
+++ b/doc/flex/flex-x.md
@@ -1,0 +1,86 @@
+# Flex-x
+
+Assign a numeric flex factor to a child widget using `flex-N`, where `N` is a positive integer. Higher numbers claim proportionally more space.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/flex_x" size="md" source="example/lib/pages/flex/flex_x.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'flex-row bg-gray-200',
+  children: [
+    WCard(
+      className: 'flex-2 bg-blue-500',
+      child: WText('Flex 2'),
+    ),
+    WCard(
+      className: 'flex-1 bg-green-500',
+      child: WText('Flex 1'),
+    ),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use `flex-N` on a child widget to assign it a flex factor. The space is divided proportionally: a child with `flex-2` receives twice the space of a sibling with `flex-1`.
+
+Under the hood, `flex-N` resolves to `FlexFit.tight` with a `flex` value of `N`. This wraps the child in a Flutter `Flexible` widget.
+
+```dart
+WFlexContainer(
+  className: 'flex-row bg-gray-200',
+  children: [
+    WCard(className: 'flex-3 bg-blue-500', child: WText('3 parts')),
+    WCard(className: 'flex-1 bg-green-500', child: WText('1 part')),
+    WCard(className: 'flex-1 bg-red-500', child: WText('1 part')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Syntax | Flex Factor | FlexFit | Description |
+|:-------|:------------|:--------|:------------|
+| `flex-1` | `1` | `FlexFit.tight` | Child receives 1 proportional share |
+| `flex-2` | `2` | `FlexFit.tight` | Child receives 2 proportional shares |
+| `flex-N` | `N` | `FlexFit.tight` | Child receives N proportional shares |
+
+Any positive integer is accepted for `N`.
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix `flex-N` with a breakpoint to change the flex factor at specific screen sizes.
+
+```dart
+WFlexContainer(
+  className: 'flex-row bg-gray-200',
+  children: [
+    WCard(
+      className: 'flex-1 md:flex-2 bg-blue-500',
+      child: WText('Grows on md+'),
+    ),
+    WCard(
+      className: 'flex-1 bg-green-500',
+      child: WText('Always 1'),
+    ),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex Fit](./flex-fit.md) — `flex-grow` / `flex-auto` for non-numeric flex sizing.
+- [Axis Sizes](./axis-sizes.md) — control the container's main-axis size.
+- [WFlexible](../widgets/wflexible.md) — the widget that wraps Flutter `Flexible`.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.

--- a/doc/flex/gap.md
+++ b/doc/flex/gap.md
@@ -1,0 +1,97 @@
+# Gap
+
+Add consistent spacing between flex children using `gap-N` (scaled by the pixel factor) or `gap-[N]` (fixed pixels).
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/gap" size="md" source="example/lib/pages/flex/gap.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'flex-row gap-4 bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-16 h-16', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 w-16 h-16', child: WText('Card 2')),
+    WCard(className: 'bg-red-500 w-16 h-16', child: WText('Card 3')),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`gap-N` multiplies `N` by the current pixel factor (default `4`) to produce the gap in logical pixels. For example, `gap-4` produces `4 × 4 = 16 px` at the default factor.
+
+The gap is inserted between children along the flex direction — `flex-row` inserts horizontal gaps, `flex-col` inserts vertical gaps.
+
+```dart
+WFlexContainer(
+  className: 'flex-col gap-2 bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-full h-16', child: WText('Row 1')),
+    WCard(className: 'bg-green-500 w-full h-16', child: WText('Row 2')),
+    WCard(className: 'bg-red-500 w-full h-16', child: WText('Row 3')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Syntax | Gap (default pixel factor 4) | Description |
+|:-------|:-----------------------------|:------------|
+| `gap-1` | `4 px` | 1 unit of spacing |
+| `gap-2` | `8 px` | 2 units of spacing |
+| `gap-4` | `16 px` | 4 units of spacing |
+| `gap-8` | `32 px` | 8 units of spacing |
+
+Any integer value is accepted. The actual pixel size is `N × pixelFactor`.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use `gap-[N]` to set a fixed pixel gap that is not scaled by the pixel factor.
+
+<x-preview path="flex/gap_dynamic" size="md" source="example/lib/pages/flex/gap_dynamic.dart"></x-preview>
+
+```dart
+WFlexContainer(
+  className: 'gap-[8] flex-row bg-gray-200',
+  children: [
+    WCard(className: 'bg-blue-500 w-16 h-16', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 w-16 h-16', child: WText('Card 2')),
+    WCard(className: 'bg-red-500 w-16 h-16', child: WText('Card 3')),
+  ],
+);
+```
+
+The value inside `[...]` is treated as a literal pixel count (`8` → `8 px`).
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix `gap-N` or `gap-[N]` with a breakpoint to apply different spacing at specific screen sizes.
+
+```dart
+WFlexContainer(
+  className: 'flex-row gap-2 md:gap-4 lg:gap-8 bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-16 h-16', child: WText('A')),
+    WCard(className: 'bg-green-500 w-16 h-16', child: WText('B')),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex Direction](./flex-direction.md) — determines the axis along which the gap is applied.
+- [Align Items](./align-items.md) — control cross-axis alignment.
+- [Justify Content](./justify-content.md) — control main-axis spacing with alignment utilities.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.

--- a/doc/flex/justify-content.md
+++ b/doc/flex/justify-content.md
@@ -1,0 +1,75 @@
+# Justify Content
+
+Control how children are distributed along the main axis of a flex container using the `justify-*` utilities.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/justify_content" size="md" source="example/lib/pages/flex/justify_content.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WFlexContainer(
+  className: 'flex-row justify-between bg-gray-200',
+  children: [
+    WCard(className: 'bg-blue-500 w-16 h-16', child: WText('Card 1')),
+    WCard(className: 'bg-green-500 w-16 h-16', child: WText('Card 2')),
+    WCard(className: 'bg-red-500 w-16 h-16', child: WText('Card 3')),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+The `justify-*` utilities map directly to Flutter's `MainAxisAlignment` values and control how children are spaced along the main axis of a flex container.
+
+```dart
+WFlexContainer(
+  className: 'flex-row justify-center bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-16 h-16', child: WText('A')),
+    WCard(className: 'bg-green-500 w-16 h-16', child: WText('B')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | MainAxisAlignment | Description |
+|:------|:------------------|:------------|
+| `justify-center` | `MainAxisAlignment.center` | Center children along the main axis |
+| `justify-start` | `MainAxisAlignment.start` | Align children to the start of the main axis |
+| `justify-end` | `MainAxisAlignment.end` | Align children to the end of the main axis |
+| `justify-between` | `MainAxisAlignment.spaceBetween` | Place equal space between children |
+| `justify-around` | `MainAxisAlignment.spaceAround` | Place equal space around each child |
+| `justify-evenly` | `MainAxisAlignment.spaceEvenly` | Distribute children with equal spacing including edges |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any `justify-*` class with a breakpoint to change alignment at specific screen sizes.
+
+```dart
+WFlexContainer(
+  className: 'flex-row justify-start md:justify-between lg:justify-evenly bg-gray-100',
+  children: [
+    WCard(className: 'bg-blue-500 w-16 h-16', child: WText('A')),
+    WCard(className: 'bg-green-500 w-16 h-16', child: WText('B')),
+    WCard(className: 'bg-red-500 w-16 h-16', child: WText('C')),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Align Items](./align-items.md) — control alignment along the cross axis.
+- [Flex Direction](./flex-direction.md) — control whether the main axis runs horizontally or vertically.
+- [Gap](./gap.md) — add fixed spacing between children.
+- [WFlexContainer](../widgets/wflexcontainer.md) — the primary flex layout widget.
+- [WFlex](../widgets/wflex.md) — alternative flex container.

--- a/doc/getting-started/binding-the-flutter-theme.md
+++ b/doc/getting-started/binding-the-flutter-theme.md
@@ -1,0 +1,116 @@
+# Binding the Flutter Theme
+
+Bind the Wind theme to your `MaterialApp` so your app's Material defaults and Wind's utility-first styles stay consistent.
+
+- [Dynamic Binding](#dynamic-binding)
+- [Static Binding](#static-binding)
+- [Customization Parameters](#customization-parameters)
+- [Related Documentation](#related-documentation)
+
+```dart
+MaterialApp(
+  theme: WindTheme.toThemeData(
+    primarySwatch: Colors.blue,
+    bodyFontString: 'Roboto',
+    displayFontString: 'Lobster',
+  ),
+)
+```
+
+Wind exposes two ways to produce a `ThemeData`:
+
+1. **Dynamic Mode** with `WindTheme.toThemeCallback`, which adapts to runtime changes such as light/dark mode transitions automatically.
+2. **Static Mode** with `WindTheme.toThemeData`, which is simpler to set up but requires manual updates when the brightness changes at runtime.
+
+`WindTheme` is a static class, so you call these methods directly on the type. There is no theme-data object or builder to instantiate.
+
+<a name="dynamic-binding"></a>
+## Dynamic Binding
+
+`WindTheme.toThemeCallback` updates the theme in response to runtime changes like light or dark mode toggling. It reads the brightness from the current `BuildContext` (or from the `brightness` you pass) and keeps the app in sync without manual intervention.
+
+```dart
+class MyApp extends StatelessWidget {
+  final Widget Function(BuildContext) appCallback;
+
+  const MyApp({super.key, required this.appCallback});
+
+  @override
+  Widget build(BuildContext context) {
+    return appCallback(context);
+  }
+}
+
+void main() {
+  runApp(MyApp(
+    appCallback: (context) {
+      return MaterialApp(
+        theme: WindTheme.toThemeCallback(
+          context,
+          primarySwatch: Colors.blue,
+          bodyFontString: 'Roboto',
+          displayFontString: 'Lobster',
+        ),
+      );
+    },
+  ));
+}
+```
+
+`toThemeCallback` resolves the brightness from the context (via `setTypeFromContext`) unless you pass an explicit `brightness`, then delegates to `toThemeData`. This makes it the right choice for dynamic theme transitions.
+
+<a name="static-binding"></a>
+## Static Binding
+
+If you do not need runtime adaptability, `WindTheme.toThemeData` is the simpler option. It applies the theme statically. When the brightness changes during runtime, update the theme manually by calling `WindTheme.setType`.
+
+```dart
+void main() {
+  runApp(MaterialApp(
+    theme: WindTheme.toThemeData(
+      primarySwatch: Colors.green,
+      bodyFontString: 'Open Sans',
+      displayFontString: 'Pacifico',
+      backgroundColor: Colors.grey.shade200,
+      brightness: Brightness.light,
+    ),
+  ));
+}
+```
+
+To switch to dark mode at runtime:
+
+```dart
+WindTheme.setType(Brightness.dark);
+```
+
+Calling `setType` regenerates Wind's darkened color set so the theme reflects the new brightness state.
+
+<a name="customization-parameters"></a>
+## Customization Parameters
+
+Both `toThemeData` and `toThemeCallback` accept the same named parameters to customize the Material theme:
+
+| Parameter | Description | Default Value |
+|:---|:---|:---|
+| `textTheme` | Custom `TextTheme` for the app's typography. | `Typography.material2021().englishLike` |
+| `bodyFontString` | Font family for body text. | `WindTheme.getBodyFontString()` |
+| `displayFontString` | Font family for display text (e.g. headings). | `WindTheme.getDisplayFontString()` |
+| `primarySwatch` | Primary color swatch for the app. | `WindTheme.getMaterialColor('primary')` |
+| `accentColor` | Secondary accent color. | `WindTheme.getColor('secondary')` |
+| `cardColor` | Background color for cards. | `WindTheme.getColor('white')` |
+| `backgroundColor` | Default background color for the app. | `WindTheme.getColor('gray', shade: 50)` |
+| `errorColor` | Color used for error states. | `WindTheme.getColor('red')` |
+| `brightness` | Overall brightness (light or dark mode). | Current `WindTheme` type |
+
+The defaults above are the ones `toThemeData` applies. `toThemeCallback` differs on two: it defaults `textTheme` to `Theme.of(context).textTheme` and resolves `brightness` from the current `BuildContext` (unless you pass an explicit value), which is what makes it adapt to runtime light/dark changes.
+
+Choose the method that best fits your application's needs.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Get Started with Wind](installation.md) — install Wind and style your first widget.
+- [Dark Mode](../concepts/dark-mode.md) — how Wind handles brightness and color inversion.
+- [Colors](../customization/colors.md) — customize the palette `toThemeData` reads from.
+- [Font Family](../customization/font-family.md) — set the body and display fonts.

--- a/doc/getting-started/installation.md
+++ b/doc/getting-started/installation.md
@@ -1,0 +1,82 @@
+# Get Started with Wind
+
+Wind enables seamless styling in Flutter by interpreting class names directly in your widget trees, transforming them into optimized designs.
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Binding the Flutter Theme](#binding-the-flutter-theme)
+- [Related Documentation](#related-documentation)
+
+<a name="requirements"></a>
+## Requirements
+
+Wind is a pure Flutter package with no platform-specific setup. To use it you need:
+
+- Flutter `>=3.3.0`
+- Dart `>=3.6.0`
+
+<a name="installation"></a>
+## Installation
+
+To get started, run the following command in your terminal:
+
+```bash
+flutter pub add fluttersdk_wind
+```
+
+Or add the following to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  fluttersdk_wind: ^0.0.4
+```
+
+Then run `flutter pub get`.
+
+<a name="usage"></a>
+## Usage
+
+Below is an example of how to use Wind to style your Flutter widgets.
+
+This example builds a card component with several text elements, each styled with Wind classes:
+
+```dart
+WCard(
+  className: 'shadow-lg rounded-lg m-4 p-4 bg-black',
+  child: WFlex(
+    className: 'flex-col axis-min gap-2 items-start',
+    children: [
+      WText('12', className: 'text-4xl leading-6 font-bold text-white'),
+      WText(
+        'Active users on the website',
+        className: 'text-white leading-4',
+      ),
+      WText(
+        'A short summary of recent activity across the platform.',
+        className: 'text-gray-300 text-xs',
+      ),
+    ],
+  ),
+)
+```
+
+`WCard` provides the surface, `WFlex` arranges its children along an axis, and each `WText` carries its own typography and color utilities.
+
+<a name="binding-the-flutter-theme"></a>
+## Binding the Flutter Theme
+
+By binding the Wind theme to your Flutter application, you can merge your app's colors and styles with Wind's theming system.
+
+This step is optional, but recommended: it keeps your Material design and your Wind utilities consistent across the whole app.
+
+See [Binding the Flutter Theme](binding-the-flutter-theme.md) for how to wire the Wind theme into your `MaterialApp`.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Binding the Flutter Theme](binding-the-flutter-theme.md) — connect Wind's theme to your `MaterialApp`.
+- [Utility-First](../concepts/utility-first.md) — the styling philosophy behind Wind.
+- [WCard](../widgets/wcard.md) — the card widget used above.
+- [WFlex](../widgets/wflex.md) — the flex layout widget used above.
+- [WText](../widgets/wtext.md) — the text widget used above.

--- a/doc/layout/display.md
+++ b/doc/layout/display.md
@@ -1,0 +1,138 @@
+# Display (Visibility)
+
+Control widget visibility with `hide` and `show` utility classes, with optional responsive breakpoint prefixes.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How It Works](#how-it-works)
+- [Responsive Display](#responsive-display)
+- [Helper Functions](#helper-functions)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="layout/display" size="md" source="example/lib/pages/layout/display.dart"></x-preview>
+
+```dart
+WFlexContainer(
+  className: 'flex-col bg-gray-100 h-64 justify-center items-center gap-4',
+  children: [
+    WFlexible(
+      className: 'hide lg:show',
+      child: WText('Visible on large and larger screens'),
+    ),
+    WFlexible(
+      className: 'hide md:show',
+      child: WText('Visible on medium and larger screens'),
+    ),
+    WFlexible(
+      className: 'show md:hide',
+      child: WText('Visible on only small screens'),
+    ),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply `hide` to a widget's `className` to hide it unconditionally. Apply `show` to force it visible.
+Combine with a breakpoint prefix to make the behavior screen-size-conditional.
+
+```dart
+WContainer(
+  className: 'hide',
+  child: WText('This widget is hidden'),
+);
+
+WContainer(
+  className: 'show',
+  child: WText('This widget is visible'),
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Description |
+| :--- | :--- |
+| `hide` | Hides the widget (replaces it with `SizedBox.shrink()`) |
+| `show` | Forces the widget to be visible |
+
+Responsive prefix syntax: `<breakpoint>:<class>` — for example `md:hide`, `lg:show`.
+
+<a name="how-it-works"></a>
+## How It Works
+
+Wind's `DisplayParser` reads the `className` string. When a `hide` token is matched (and any breakpoint
+condition is satisfied), the widget is replaced with `SizedBox.shrink()`. The `show` token overrides
+a previous `hide` on the same widget.
+
+This behavior is built into:
+
+- `WText`
+- `WFlexible`
+- `WContainer`
+- `WCard`
+
+<a name="responsive-display"></a>
+## Responsive Display
+
+Prefix any display class with a breakpoint to apply it only at that screen width and above.
+
+| Breakpoint | Min-width |
+| :--- | :--- |
+| `sm:` | 640 px |
+| `md:` | 768 px |
+| `lg:` | 1024 px |
+| `xl:` | 1280 px |
+| `2xl:` | 1536 px |
+
+```dart
+// Visible only on small screens; hidden on medium and above.
+WFlexible(
+  className: 'show md:hide',
+  child: WText('Mobile only'),
+);
+
+// Hidden by default; shown on large screens and above.
+WFlexible(
+  className: 'hide lg:show',
+  child: WText('Desktop only'),
+);
+```
+
+<a name="helper-functions"></a>
+## Helper Functions
+
+Wind exposes Dart helpers for imperative visibility logic.
+
+### `wScreen`
+
+Returns `true` if the current screen width is at or above the given breakpoint.
+
+```dart
+wScreen(context, 'md') // true on medium and larger screens
+```
+
+### `wScreenOnly`
+
+Returns `true` only when the screen width falls within the exact range of the given breakpoint.
+
+```dart
+wScreenOnly(context, 'sm') // true only on small screens
+```
+
+### `wAnyScreenOnly`
+
+Returns `true` when the screen matches any of the provided breakpoints exclusively.
+
+```dart
+wAnyScreenOnly(context, ['sm', 'md']) // true on small or medium only
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Responsive Design](../concepts/responsive-design.md) — breakpoint system and screen-size utilities
+- [WContainer](../widgets/wcontainer.md) — container widget supporting display classes
+- [WFlexible](../widgets/wflexible.md) — flex child widget supporting display classes
+- [WText](../widgets/wtext.md) — text widget supporting display classes

--- a/doc/layout/overflow.md
+++ b/doc/layout/overflow.md
@@ -1,0 +1,78 @@
+# Overflow
+
+Make content scrollable when it exceeds the available space using the `overflow-scroll` utility class.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How It Works](#how-it-works)
+- [Responsive Overflow](#responsive-overflow)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="flex/scrollable_overflow" size="md" source="example/lib/pages/flex/scrollable_overflow.dart"></x-preview>
+
+```dart
+WFlexContainer(
+  className: 'overflow-scroll flex-col bg-gray-100 h-64',
+  children: List.generate(
+    20,
+    (index) => WCard(
+      className: 'bg-gray-200 w-full h-10',
+      child: WText('Item $index', className: 'text-black'),
+    ),
+  ),
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply `overflow-scroll` to a `WFlexContainer` to wrap its content in a `SingleChildScrollView` when
+the content height exceeds the container's available space.
+
+```dart
+WFlexContainer(
+  className: 'overflow-scroll flex-col bg-white h-48',
+  children: [
+    WCard(className: 'bg-gray-100 w-full h-12', child: WText('Row 1')),
+    WCard(className: 'bg-gray-100 w-full h-12', child: WText('Row 2')),
+    WCard(className: 'bg-gray-100 w-full h-12', child: WText('Row 3')),
+    WCard(className: 'bg-gray-100 w-full h-12', child: WText('Row 4')),
+    WCard(className: 'bg-gray-100 w-full h-12', child: WText('Row 5')),
+  ],
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Description |
+| :--- | :--- |
+| `overflow-scroll` | Wraps content in a `SingleChildScrollView` when overflow occurs |
+
+<a name="how-it-works"></a>
+## How It Works
+
+When `overflow-scroll` is present in the `className`, `FlexParser.applyOverflow` wraps the flex
+content in a `SingleChildScrollView`. This is applied to `WFlexContainer` only; the scroll direction
+follows the flex axis.
+
+<a name="responsive-overflow"></a>
+## Responsive Overflow
+
+The `overflow-scroll` token supports responsive breakpoint prefixes, allowing overflow behavior to
+activate only at certain screen sizes.
+
+```dart
+// Scrollable only on small screens; normal layout on medium and above.
+WFlexContainer(
+  className: 'sm:overflow-scroll md:flex-row flex-col bg-gray-100',
+  children: [...],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Flex Direction](../flex/flex-direction.md) — `flex-col` and `flex-row` layout direction
+- [Axis Sizes](../flex/axis-sizes.md) — controlling main-axis size
+- [WFlexContainer](../widgets/wflexcontainer.md) — the widget that applies overflow behavior

--- a/doc/sizing/height.md
+++ b/doc/sizing/height.md
@@ -1,0 +1,129 @@
+# Height
+
+Control the height of widgets using the `h-*` utilities. Supports pixel-based, percentage-based, and viewport-relative values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How Values Are Calculated](#how-values-are-calculated)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="sizing/height" size="md" source="example/lib/pages/sizing/height.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'h-12 bg-blue-500 dark:bg-blue-700',
+  child: WText('Height is 48px'), // 12 * 4 (Pixel Factor)
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Set the height of any `WContainer` by adding an `h-*` class. The predefined value is multiplied by the Pixel Factor (default 4), so `h-12` produces 48px. Use `h-full` for 100% of the parent's height or `h-[value]` for an exact pixel value.
+
+```dart
+WContainer(
+  className: 'h-[150] bg-red-500 dark:bg-red-700',
+  child: WText('Height is 150px'), // Arbitrary value
+)
+
+WContainer(
+  className: 'h-full bg-green-500 dark:bg-green-700',
+  child: WText('Full height of parent'),
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `h-{value}` | Height in pixels (scaled by Pixel Factor) | `h-12` |
+| `h-[{value}]` | Arbitrary height in pixels | `h-[150]` |
+| `h-full` | 100% of the parent's height | `h-full` |
+| `h-max` | Infinite height | `h-max` |
+| `h-min` | Minimum possible height (0px) | `h-min` |
+| `h-{x}/{y}` | Percentage of the parent's height | `h-1/2` |
+| `h-[{value}vh]` | Percentage of the viewport height | `h-[50vh]` |
+| `h-screen` | 100% of the viewport height | `h-screen` |
+
+<a name="how-values-are-calculated"></a>
+## How Values Are Calculated
+
+### Predefined Sizes
+
+Height is calculated using the size value multiplied by the Pixel Factor.
+
+- Example: `h-12` → 12 × 4 (Pixel Factor) = **48px**.
+
+### Special Keywords
+
+| Value | Result |
+|:------|:-------|
+| `full` | `double.infinity` (100% of parent) |
+| `max` | `double.infinity` |
+| `min` | `0.0` |
+| `screen` | Viewport height via `MediaQuery` |
+
+### Fraction Syntax
+
+Use `h-x/y` to express a fraction of the parent height.
+
+- Example: `h-1/2` → 50% of the parent's height.
+
+### Viewport Height
+
+Append `vh` inside brackets for a percentage of the viewport.
+
+- Example: `h-[50vh]` → 50% of the viewport height.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to apply any exact pixel value directly, bypassing the Pixel Factor.
+
+```dart
+WContainer(
+  className: 'h-[200] bg-gray-300 dark:bg-gray-600',
+  child: WText('Height is exactly 200px.'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any `h-*` class with a breakpoint to change height at specific screen sizes.
+
+```dart
+WContainer(
+  className: 'h-32 md:h-48 lg:h-64 bg-blue-500 dark:bg-blue-700',
+  child: WText('Responsive height.'),
+)
+```
+
+Available breakpoints: `sm`, `md`, `lg`, `xl`, `2xl`.
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Predefined height values are scaled by the Pixel Factor. Adjust it to change the base unit.
+
+```dart
+WindTheme.setPixelFactor(3); // h-12 now produces 36px instead of 48px
+```
+
+See [Pixel Factor](../customization/pixel-factor.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Width](./width.md) — control widget width.
+- [Max-Height and Min-Height](./max-height-min-height.md) — constrain the maximum and minimum height.
+- [Padding](../spacing/padding.md) — apply inner spacing.
+- [Margin](../spacing/margin.md) — apply outer spacing.
+- [WContainer](../widgets/wcontainer.md) — the primary container widget.

--- a/doc/sizing/max-height-min-height.md
+++ b/doc/sizing/max-height-min-height.md
@@ -1,0 +1,130 @@
+# Max-Height and Min-Height
+
+Constrain the maximum and minimum heights of widgets using the `max-h-*` and `min-h-*` utilities. Supports pixel-based, percentage-based, and viewport-relative values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How Values Are Calculated](#how-values-are-calculated)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'max-h-[200] bg-blue-500 dark:bg-blue-700',
+  child: WText('Max height: 200px'),
+)
+
+WContainer(
+  className: 'min-h-[100] bg-orange-500 dark:bg-orange-700',
+  child: WText('Min height: 100px'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use `max-h-*` to prevent a widget from growing beyond a certain height. Use `min-h-*` to ensure it never shrinks below a minimum. Both accept the same value forms as the `h-*` utilities.
+
+```dart
+WContainer(
+  className: 'max-h-16 bg-blue-500 dark:bg-blue-700',
+  child: WText('Max height: 64px'), // 16 * 4 (Pixel Factor)
+)
+
+WContainer(
+  className: 'min-h-10 bg-yellow-500 dark:bg-yellow-700',
+  child: WText('Min height: 40px'), // 10 * 4 (Pixel Factor)
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Max-Height
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `max-h-{value}` | Maximum height in pixels (scaled by Pixel Factor) | `max-h-20` |
+| `max-h-[{value}]` | Arbitrary maximum height in pixels | `max-h-[200]` |
+| `max-h-full` | 100% of the parent's height | `max-h-full` |
+| `max-h-screen` | 100% of the viewport height | `max-h-screen` |
+| `max-h-{x}/{y}` | Percentage of the parent's height | `max-h-1/2` |
+| `max-h-[{value}vh]` | Percentage of the viewport height | `max-h-[90vh]` |
+
+### Min-Height
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `min-h-{value}` | Minimum height in pixels (scaled by Pixel Factor) | `min-h-20` |
+| `min-h-[{value}]` | Arbitrary minimum height in pixels | `min-h-[200]` |
+| `min-h-full` | 100% of the parent's height | `min-h-full` |
+| `min-h-screen` | 100% of the viewport height | `min-h-screen` |
+| `min-h-{x}/{y}` | Percentage of the parent's height | `min-h-1/2` |
+| `min-h-[{value}vh]` | Percentage of the viewport height | `min-h-[90vh]` |
+
+<a name="how-values-are-calculated"></a>
+## How Values Are Calculated
+
+### Predefined Sizes
+
+Values are multiplied by the Pixel Factor.
+
+- Example: `max-h-16` → 16 × 4 (Pixel Factor) = **64px**.
+- Example: `min-h-10` → 10 × 4 (Pixel Factor) = **40px**.
+
+### Special Keywords
+
+| Value | Result |
+|:------|:-------|
+| `full` | `double.infinity` (100% of parent) |
+| `screen` | Viewport height via `MediaQuery` |
+
+### Fraction Syntax
+
+Use `max-h-x/y` or `min-h-x/y` to express a fraction of the parent height.
+
+- Example: `max-h-3/4` → 75% of the parent's height.
+
+### Viewport Height
+
+Append `vh` inside brackets for a percentage of the viewport.
+
+- Example: `max-h-[90vh]` → 90% of the viewport height.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation for an exact pixel value, bypassing the Pixel Factor.
+
+```dart
+WContainer(
+  className: 'max-h-[400] min-h-[100] bg-gray-200 dark:bg-gray-700',
+  child: WText('Height stays between 100px and 400px.'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine max/min height with breakpoint prefixes for responsive constraints.
+
+```dart
+WContainer(
+  className: 'max-h-[300] md:max-h-[500] lg:max-h-screen bg-blue-500 dark:bg-blue-700',
+  child: WText('Responsive max-height.'),
+)
+```
+
+Available breakpoints: `sm`, `md`, `lg`, `xl`, `2xl`.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Height](./height.md) — control widget height directly.
+- [Max-Width and Min-Width](./max-width-min-width.md) — constrain width bounds.
+- [Width](./width.md) — control widget width directly.
+- [Pixel Factor](../customization/pixel-factor.md) — configure the base unit.
+- [WContainer](../widgets/wcontainer.md) — the primary container widget.

--- a/doc/sizing/max-width-min-width.md
+++ b/doc/sizing/max-width-min-width.md
@@ -1,0 +1,130 @@
+# Max-Width and Min-Width
+
+Constrain the maximum and minimum widths of widgets using the `max-w-*` and `min-w-*` utilities. Supports pixel-based, percentage-based, and viewport-relative values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How Values Are Calculated](#how-values-are-calculated)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'max-w-[300] bg-purple-500 dark:bg-purple-700',
+  child: WText('Max width: 300px'),
+)
+
+WContainer(
+  className: 'min-w-[100] bg-orange-500 dark:bg-orange-700',
+  child: WText('Min width: 100px'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Use `max-w-*` to prevent a widget from growing beyond a certain width. Use `min-w-*` to ensure it never shrinks below a minimum. Both accept the same value forms as the `w-*` utilities.
+
+```dart
+WContainer(
+  className: 'max-w-10 bg-purple-500 dark:bg-purple-700',
+  child: WText('Max width: 40px'), // 10 * 4 (Pixel Factor)
+)
+
+WContainer(
+  className: 'min-w-12 bg-yellow-500 dark:bg-yellow-700',
+  child: WText('Min width: 48px'), // 12 * 4 (Pixel Factor)
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+### Max-Width
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `max-w-{value}` | Maximum width in pixels (scaled by Pixel Factor) | `max-w-20` |
+| `max-w-[{value}]` | Arbitrary maximum width in pixels | `max-w-[300]` |
+| `max-w-full` | 100% of the parent's width | `max-w-full` |
+| `max-w-screen` | 100% of the viewport width | `max-w-screen` |
+| `max-w-{x}/{y}` | Percentage of the parent's width | `max-w-1/2` |
+| `max-w-[{value}vw]` | Percentage of the viewport width | `max-w-[80vw]` |
+
+### Min-Width
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `min-w-{value}` | Minimum width in pixels (scaled by Pixel Factor) | `min-w-20` |
+| `min-w-[{value}]` | Arbitrary minimum width in pixels | `min-w-[300]` |
+| `min-w-full` | 100% of the parent's width | `min-w-full` |
+| `min-w-screen` | 100% of the viewport width | `min-w-screen` |
+| `min-w-{x}/{y}` | Percentage of the parent's width | `min-w-1/2` |
+| `min-w-[{value}vw]` | Percentage of the viewport width | `min-w-[80vw]` |
+
+<a name="how-values-are-calculated"></a>
+## How Values Are Calculated
+
+### Predefined Sizes
+
+Values are multiplied by the Pixel Factor.
+
+- Example: `max-w-20` → 20 × 4 (Pixel Factor) = **80px**.
+- Example: `min-w-12` → 12 × 4 (Pixel Factor) = **48px**.
+
+### Special Keywords
+
+| Value | Result |
+|:------|:-------|
+| `full` | `double.infinity` (100% of parent) |
+| `screen` | Viewport width via `MediaQuery` |
+
+### Fraction Syntax
+
+Use `max-w-x/y` or `min-w-x/y` to express a fraction of the parent width.
+
+- Example: `max-w-3/4` → 75% of the parent's width.
+
+### Viewport Width
+
+Append `vw` inside brackets for a percentage of the viewport.
+
+- Example: `max-w-[80vw]` → 80% of the viewport width.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation for an exact pixel value, bypassing the Pixel Factor.
+
+```dart
+WContainer(
+  className: 'max-w-[600] min-w-[200] bg-gray-200 dark:bg-gray-700',
+  child: WText('Width stays between 200px and 600px.'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine max/min width with breakpoint prefixes for responsive constraints.
+
+```dart
+WContainer(
+  className: 'max-w-full md:max-w-[600] lg:max-w-[800] bg-blue-500 dark:bg-blue-700',
+  child: WText('Responsive max-width.'),
+)
+```
+
+Available breakpoints: `sm`, `md`, `lg`, `xl`, `2xl`.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Width](./width.md) — control widget width directly.
+- [Max-Height and Min-Height](./max-height-min-height.md) — constrain height bounds.
+- [Height](./height.md) — control widget height directly.
+- [Pixel Factor](../customization/pixel-factor.md) — configure the base unit.
+- [WContainer](../widgets/wcontainer.md) — the primary container widget.

--- a/doc/sizing/width.md
+++ b/doc/sizing/width.md
@@ -1,0 +1,129 @@
+# Width
+
+Control the width of widgets using the `w-*` utilities. Supports pixel-based, percentage-based, and viewport-relative values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How Values Are Calculated](#how-values-are-calculated)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="sizing/width" size="md" source="example/lib/pages/sizing/width.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'w-12 bg-blue-500 dark:bg-blue-700',
+  child: WText('Width is 48px'), // 12 * 4 (Pixel Factor)
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Set the width of any `WContainer` by adding a `w-*` class. The predefined value is multiplied by the Pixel Factor (default 4), so `w-12` produces 48px. Use `w-full` for 100% of the parent's width or `w-[value]` for an exact pixel value.
+
+```dart
+WContainer(
+  className: 'w-[150] bg-red-500 dark:bg-red-700',
+  child: WText('Width is 150px'), // Arbitrary value
+)
+
+WContainer(
+  className: 'w-full bg-green-500 dark:bg-green-700',
+  child: WText('Full width of parent'),
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `w-{value}` | Width in pixels (scaled by Pixel Factor) | `w-12` |
+| `w-[{value}]` | Arbitrary width in pixels | `w-[150]` |
+| `w-full` | 100% of the parent's width | `w-full` |
+| `w-max` | Infinite width | `w-max` |
+| `w-min` | Minimum possible width (0px) | `w-min` |
+| `w-{x}/{y}` | Percentage of the parent's width | `w-1/2` |
+| `w-[{value}vw]` | Percentage of the viewport width | `w-[50vw]` |
+| `w-screen` | 100% of the viewport width | `w-screen` |
+
+<a name="how-values-are-calculated"></a>
+## How Values Are Calculated
+
+### Predefined Sizes
+
+Width is calculated using the size value multiplied by the Pixel Factor.
+
+- Example: `w-12` → 12 × 4 (Pixel Factor) = **48px**.
+
+### Special Keywords
+
+| Value | Result |
+|:------|:-------|
+| `full` | `double.infinity` (100% of parent) |
+| `max` | `double.infinity` |
+| `min` | `0.0` |
+| `screen` | Viewport width via `MediaQuery` |
+
+### Fraction Syntax
+
+Use `w-x/y` to express a fraction of the parent width.
+
+- Example: `w-1/2` → 50% of the parent's width.
+
+### Viewport Width
+
+Append `vw` inside brackets for a percentage of the viewport.
+
+- Example: `w-[50vw]` → 50% of the viewport width.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to apply any exact pixel value directly, bypassing the Pixel Factor.
+
+```dart
+WContainer(
+  className: 'w-[200] bg-gray-300 dark:bg-gray-600',
+  child: WText('Width is exactly 200px.'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any `w-*` class with a breakpoint to change width at specific screen sizes.
+
+```dart
+WContainer(
+  className: 'w-full md:w-1/2 lg:w-1/3 bg-blue-500 dark:bg-blue-700',
+  child: WText('Responsive width.'),
+)
+```
+
+Available breakpoints: `sm`, `md`, `lg`, `xl`, `2xl`.
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Predefined width values are scaled by the Pixel Factor. Adjust it to change the base unit.
+
+```dart
+WindTheme.setPixelFactor(3); // w-12 now produces 36px instead of 48px
+```
+
+See [Pixel Factor](../customization/pixel-factor.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Height](./height.md) — control widget height.
+- [Max-Width and Min-Width](./max-width-min-width.md) — constrain the maximum and minimum width.
+- [Padding](../spacing/padding.md) — apply inner spacing.
+- [Margin](../spacing/margin.md) — apply outer spacing.
+- [WContainer](../widgets/wcontainer.md) — the primary container widget.

--- a/doc/spacing/margin.md
+++ b/doc/spacing/margin.md
@@ -1,0 +1,115 @@
+# Margin
+
+Apply outer spacing to widgets using the `m-*` utilities. Values are multiplied by the Pixel Factor or used directly as arbitrary pixel values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How Values Are Calculated](#how-values-are-calculated)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="spacing/margin" size="md" source="example/lib/pages/spacing/margin.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'm-4 bg-gray-200 dark:bg-gray-700',
+  child: WText('This container has 16px margin.'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Margin is applied by adding an `m-*` class to any `WContainer` or widget that accepts `className`. The value is scaled by the Pixel Factor (default 4), so `m-4` produces 16px of margin on all sides.
+
+```dart
+WContainer(
+  className: 'mt-4 mr-[8] ml-2 mb-[12] bg-gray-200 dark:bg-gray-700',
+  child: WText('Custom side-specific margin applied.'),
+)
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `m-{value}` | Margin on all sides | `m-4`, `m-[6]` |
+| `mx-{value}` | Horizontal margin (left + right) | `mx-4`, `mx-[6]` |
+| `my-{value}` | Vertical margin (top + bottom) | `my-4`, `my-[6]` |
+| `mt-{value}` | Top margin | `mt-4`, `mt-[6]` |
+| `mb-{value}` | Bottom margin | `mb-4`, `mb-[6]` |
+| `ml-{value}` | Left margin | `ml-4`, `ml-[6]` |
+| `mr-{value}` | Right margin | `mr-4`, `mr-[6]` |
+
+<a name="how-values-are-calculated"></a>
+## How Values Are Calculated
+
+### Predefined Sizes
+
+Margin is calculated using the size value multiplied by the Pixel Factor.
+
+- Example: `m-4` → 4 (size) × 4 (Pixel Factor) = **16px**.
+
+### Arbitrary Values
+
+Arbitrary sizes wrapped in brackets bypass the Pixel Factor and use the value directly in pixels.
+
+- Example: `m-[6]` → **6px**.
+
+```dart
+WContainer(
+  className: 'm-[10] bg-gray-200 dark:bg-gray-700',
+  child: WText('This container has 10px margin.'),
+)
+```
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to apply any pixel value directly without scaling. The bracket form expects a unitless integer or decimal.
+
+```dart
+WContainer(
+  className: 'mt-[24] mb-[8] mx-[16] bg-white dark:bg-gray-800',
+  child: WText('Custom arbitrary margin on each axis.'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any margin class with a breakpoint to apply it only at that screen size and above.
+
+```dart
+WContainer(
+  className: 'm-2 md:m-4 lg:m-8 bg-gray-100 dark:bg-gray-800',
+  child: WText('Responsive margin.'),
+)
+```
+
+Available breakpoints: `sm`, `md`, `lg`, `xl`, `2xl`.
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Margin values are scaled by the Pixel Factor. Adjust the Pixel Factor to change the base unit for all predefined margin values.
+
+```dart
+WindTheme.setPixelFactor(3); // m-4 now produces 12px instead of 16px
+```
+
+See [Pixel Factor](../customization/pixel-factor.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Padding](./padding.md) — apply inner spacing to widgets.
+- [Pixel Factor](../customization/pixel-factor.md) — configure the base unit used by spacing utilities.
+- [Width](../sizing/width.md) — control widget width.
+- [Height](../sizing/height.md) — control widget height.
+- [WContainer](../widgets/wcontainer.md) — the primary container widget that accepts margin classes.

--- a/doc/spacing/padding.md
+++ b/doc/spacing/padding.md
@@ -1,0 +1,117 @@
+# Padding
+
+Apply inner spacing to widgets using the `p-*` utilities. Values are multiplied by the Pixel Factor or used directly as arbitrary pixel values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [How Values Are Calculated](#how-values-are-calculated)
+- [Arbitrary Values](#arbitrary-values)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="spacing/padding" size="md" source="example/lib/pages/spacing/padding.dart"></x-preview>
+
+```dart
+import 'package:fluttersdk_wind/fluttersdk_wind.dart';
+
+WContainer(
+  className: 'p-4 bg-gray-200 dark:bg-gray-700',
+  child: WText('This container has 16px padding.'),
+)
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Padding is applied by adding a `p-*` class to any `WContainer` or widget that accepts `className`. The value is scaled by the Pixel Factor (default 4), so `p-4` produces 16px of padding on all sides.
+
+```dart
+WContainer(
+  className: 'pt-4 pr-[8] pl-2 pb-[12] bg-gray-200 dark:bg-gray-700',
+  child: WText('Custom side-specific padding applied.'),
+)
+```
+
+**Note:** As of version 0.0.3, if the resolved padding is 0 on all sides, the `PaddingParser` will not wrap the widget with a `Padding` widget at all. This reduces unnecessary widget nesting.
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Description | Example |
+|:------|:------------|:--------|
+| `p-{value}` | Padding on all sides | `p-4`, `p-[6]` |
+| `px-{value}` | Horizontal padding (left + right) | `px-4`, `px-[6]` |
+| `py-{value}` | Vertical padding (top + bottom) | `py-4`, `py-[6]` |
+| `pt-{value}` | Top padding | `pt-4`, `pt-[6]` |
+| `pb-{value}` | Bottom padding | `pb-4`, `pb-[6]` |
+| `pl-{value}` | Left padding | `pl-4`, `pl-[6]` |
+| `pr-{value}` | Right padding | `pr-4`, `pr-[6]` |
+
+<a name="how-values-are-calculated"></a>
+## How Values Are Calculated
+
+### Predefined Sizes
+
+Padding is calculated using the size value multiplied by the Pixel Factor.
+
+- Example: `p-4` → 4 (size) × 4 (Pixel Factor) = **16px**.
+
+### Arbitrary Values
+
+Arbitrary sizes wrapped in brackets bypass the Pixel Factor and use the value directly in pixels.
+
+- Example: `p-[6]` → **6px**.
+
+```dart
+WContainer(
+  className: 'p-[10] bg-gray-200 dark:bg-gray-700',
+  child: WText('This container has 10px padding.'),
+)
+```
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to apply any pixel value directly without scaling. The bracket form expects a unitless integer or decimal.
+
+```dart
+WContainer(
+  className: 'pt-[24] pb-[8] px-[16] bg-white dark:bg-gray-800',
+  child: WText('Custom arbitrary padding on each axis.'),
+)
+```
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Prefix any padding class with a breakpoint to apply it only at that screen size and above.
+
+```dart
+WContainer(
+  className: 'p-2 md:p-4 lg:p-8 bg-gray-100 dark:bg-gray-800',
+  child: WText('Responsive padding.'),
+)
+```
+
+Available breakpoints: `sm`, `md`, `lg`, `xl`, `2xl`.
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Padding values are scaled by the Pixel Factor. Adjust the Pixel Factor to change the base unit for all predefined padding values.
+
+```dart
+WindTheme.setPixelFactor(3); // p-4 now produces 12px instead of 16px
+```
+
+See [Pixel Factor](../customization/pixel-factor.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Margin](./margin.md) — apply outer spacing to widgets.
+- [Pixel Factor](../customization/pixel-factor.md) — configure the base unit used by spacing utilities.
+- [Width](../sizing/width.md) — control widget width.
+- [Height](../sizing/height.md) — control widget height.
+- [WContainer](../widgets/wcontainer.md) — the primary container widget that accepts padding classes.

--- a/doc/typography/font-size.md
+++ b/doc/typography/font-size.md
@@ -32,10 +32,10 @@ WText('Section heading', className: 'text-2xl font-bold');
 <a name="quick-reference"></a>
 ## Quick Reference
 
-Predefined sizes are resolved against the REM factor and Pixel Factor. The final size is calculated as:
+Predefined sizes are stored in rem units and resolved against the REM factor (`WindTheme.getRemFactor()`, which is pixel factor × 4 = 16 by default). The final size is calculated as:
 
 ```
-Size (REM) × REM Factor (default: 4) × Pixel Factor (default: 4) = Final size in px
+Size (rem) × REM factor (16 by default) = Final size in px
 ```
 
 | Class | REM | Default px | Description |
@@ -77,7 +77,7 @@ Add or override font size keys with `WindTheme.setFontSize(key, remValue)`:
 
 ```dart
 WindTheme.setFontSize('giant', 5);
-// Now text-giant = 5 * 4 * 4 = 80px (at default factors)
+// Now text-giant = 5 × 16 (rem factor) = 80px at the default factor
 WText('Giant text', className: 'text-giant');
 ```
 

--- a/doc/typography/font-size.md
+++ b/doc/typography/font-size.md
@@ -1,0 +1,93 @@
+# Font Size
+
+Control text size with predefined named scales or arbitrary pixel values. Font sizes can also be [customized in the theme](../customization/font-size.md) for maximum flexibility.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Arbitrary Values](#arbitrary-values)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/font_size" size="md" source="example/lib/pages/typography/font_size.dart"></x-preview>
+
+```dart
+WText('Extra Small Text', className: 'text-xs');   // 12px
+WText('Base Text', className: 'text-base');         // 16px
+WText('Large Text', className: 'text-lg');          // 18px
+WText('Gigantic Text', className: 'text-6xl');      // 64px
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply font sizes using the `text-` prefix followed by a named size key:
+
+```dart
+WText('Small label', className: 'text-sm');
+WText('Body text', className: 'text-base');
+WText('Section heading', className: 'text-2xl font-bold');
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+Predefined sizes are resolved against the REM factor and Pixel Factor. The final size is calculated as:
+
+```
+Size (REM) × REM Factor (default: 4) × Pixel Factor (default: 4) = Final size in px
+```
+
+| Class | REM | Default px | Description |
+|:------|:----|:-----------|:------------|
+| `text-xs` | 0.75 | 12px | Extra small |
+| `text-sm` | 0.875 | 14px | Small |
+| `text-base` | 1.0 | 16px | Base size |
+| `text-lg` | 1.125 | 18px | Large |
+| `text-xl` | 1.25 | 20px | Extra large |
+| `text-2xl` | 1.5 | 24px | Very large |
+| `text-3xl` | 1.875 | 30px | Extra extra large |
+| `text-4xl` | 2.25 | 36px | Huge |
+| `text-5xl` | 3.0 | 48px | Massive |
+| `text-6xl` | 4.0 | 64px | Gigantic |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine size classes with breakpoint prefixes to adjust text size per screen width:
+
+```dart
+WText('Responsive heading', className: 'text-base md:text-xl lg:text-3xl');
+```
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to set any pixel size not in the predefined scale. The value is treated as raw pixels:
+
+```dart
+WText('Custom 22px text', className: 'text-[22]');
+WText('Tiny 8px label', className: 'text-[8]');
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Add or override font size keys with `WindTheme.setFontSize(key, remValue)`:
+
+```dart
+WindTheme.setFontSize('giant', 5);
+// Now text-giant = 5 * 4 * 4 = 80px (at default factors)
+WText('Giant text', className: 'text-giant');
+```
+
+See [Customizing Font Sizes](../customization/font-size.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Weight](font-weight.md) — control text thickness.
+- [Font Style](font-style.md) — italic and normal styles.
+- [Line Height](line-height.md) — spacing between lines.
+- [Customizing Font Sizes](../customization/font-size.md) — override the default scale.
+- [Pixel Factor](../customization/pixel-factor.md) — how rem values translate to pixels.

--- a/doc/typography/font-style.md
+++ b/doc/typography/font-style.md
@@ -1,0 +1,49 @@
+# Font Style
+
+Toggle between italic and normal text style using simple class names.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/font_style" size="md" source="example/lib/pages/typography/font_style.dart"></x-preview>
+
+```dart
+WText('Italic Text', className: 'italic');
+WText('Normal Text', className: 'not-italic');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply `italic` to make text italicized, or `not-italic` to reset it to the normal font style:
+
+```dart
+WText('Important note', className: 'italic text-gray-700 dark:text-gray-300');
+WText('Regular text', className: 'not-italic');
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Flutter `FontStyle` | Description |
+|:------|:--------------------|:------------|
+| `italic` | `FontStyle.italic` | Renders text in italic. |
+| `not-italic` | `FontStyle.normal` | Resets text to normal style. |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine with breakpoint prefixes to apply italic only at certain screen sizes:
+
+```dart
+WText('Responsive italic', className: 'not-italic md:italic');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Size](font-size.md) — set text size.
+- [Font Weight](font-weight.md) — control text thickness.
+- [Text Decoration](text-decoration.md) — underline, overline, and strikethrough.

--- a/doc/typography/font-weight.md
+++ b/doc/typography/font-weight.md
@@ -1,0 +1,71 @@
+# Font Weight
+
+Control the thickness of text using predefined weight names. Font weights can also be [customized in the theme](../customization/font-weight.md).
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/font_weight" size="md" source="example/lib/pages/typography/font_weight.dart"></x-preview>
+
+```dart
+WText('Bold Text', className: 'font-bold');
+WText('Thin Text', className: 'font-thin');
+WText('Black Text', className: 'font-black');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply font weights using the `font-` prefix followed by a weight name:
+
+```dart
+WText('Normal body text', className: 'font-normal');
+WText('Section heading', className: 'font-semibold text-gray-900 dark:text-gray-100');
+WText('Strong callout', className: 'font-bold');
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Weight | Flutter `FontWeight` |
+|:------|:-------|:---------------------|
+| `font-thin` | 100 | `FontWeight.w100` |
+| `font-extralight` | 200 | `FontWeight.w200` |
+| `font-light` | 300 | `FontWeight.w300` |
+| `font-normal` | 400 | `FontWeight.w400` |
+| `font-medium` | 500 | `FontWeight.w500` |
+| `font-semibold` | 600 | `FontWeight.w600` |
+| `font-bold` | 700 | `FontWeight.w700` |
+| `font-extrabold` | 800 | `FontWeight.w800` |
+| `font-black` | 900 | `FontWeight.w900` |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine weight classes with breakpoint prefixes:
+
+```dart
+WText('Heading', className: 'font-normal md:font-semibold lg:font-bold');
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Override or extend the font weight map with `WindTheme.setFontWeight(key, fontWeight)`:
+
+```dart
+WindTheme.setFontWeight('normal', FontWeight.w500);
+// All font-normal usages now render at w500
+```
+
+See [Customizing Font Weight](../customization/font-weight.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Size](font-size.md) — set text size.
+- [Font Style](font-style.md) — italic and normal styles.
+- [Customizing Font Weight](../customization/font-weight.md) — override the default weight map.

--- a/doc/typography/letter-spacing.md
+++ b/doc/typography/letter-spacing.md
@@ -1,0 +1,81 @@
+# Letter Spacing
+
+Adjust the spacing between characters using predefined named scales or arbitrary pixel values. Letter spacings can also be [customized in the theme](../customization/letter-spacing.md).
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Arbitrary Values](#arbitrary-values)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/letter_spacing" size="md" source="example/lib/pages/typography/letter_spacing.dart"></x-preview>
+
+```dart
+WText('Wide letter spacing', className: 'tracking-wide text-lg text-gray-700 dark:text-gray-300');
+WText('Custom spacing', className: 'tracking-[0.13] text-base text-blue-500 dark:text-blue-300');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply letter spacing with the `tracking-` prefix followed by a named key:
+
+```dart
+WText('Compact label', className: 'tracking-tighter text-sm');
+WText('Spacious heading', className: 'tracking-wider text-2xl font-semibold');
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+Values are defined in em units and multiplied by the Pixel Factor (default: 4) to produce a pixel value.
+
+| Class | em value | Default px | Description |
+|:------|:---------|:-----------|:------------|
+| `tracking-tighter` | -0.05 | -0.2px | Very tight spacing |
+| `tracking-tight` | -0.025 | -0.1px | Tight spacing |
+| `tracking-normal` | 0 | 0px | Default spacing |
+| `tracking-wide` | 0.025 | 0.1px | Wide spacing |
+| `tracking-wider` | 0.05 | 0.2px | Very wide spacing |
+| `tracking-widest` | 0.1 | 0.4px | Extremely wide spacing |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine with breakpoint prefixes for viewport-dependent letter spacing:
+
+```dart
+WText('Heading', className: 'tracking-normal md:tracking-wide lg:tracking-wider');
+```
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to set a precise pixel value not in the predefined scale:
+
+```dart
+WText('Custom tracking', className: 'tracking-[0.13]');
+WText('Negative tracking', className: 'tracking-[-0.03]');
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Add or override letter spacing keys with `WindTheme.setLetterSpacing(key, emValue)`:
+
+```dart
+WindTheme.setLetterSpacing('loose', 0.15);
+// tracking-loose = 0.15 * 4 (pixel factor) = 0.6px
+WText('Loose tracking', className: 'tracking-loose');
+```
+
+See [Customizing Letter Spacing](../customization/letter-spacing.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Size](font-size.md) — set text size.
+- [Line Height](line-height.md) — spacing between lines.
+- [Customizing Letter Spacing](../customization/letter-spacing.md) — override the default scale.
+- [Pixel Factor](../customization/pixel-factor.md) — how em values translate to pixels.

--- a/doc/typography/line-height.md
+++ b/doc/typography/line-height.md
@@ -1,0 +1,87 @@
+# Line Height
+
+Control the vertical spacing between lines of text. Line heights can also be [customized in the theme](../customization/line-height.md).
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Arbitrary Values](#arbitrary-values)
+- [Customizing Theme](#customizing-theme)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/line_height" size="md" source="example/lib/pages/typography/line_height.dart"></x-preview>
+
+```dart
+WText('Comfortable spacing', className: 'text-lg leading-6');
+WText('Custom spacing', className: 'text-lg leading-[1.3]');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+In Flutter, line height is a multiplier applied to the font size. A value of `1.5` on a `16px` font produces `24px` of line height. Apply it with the `leading-` prefix:
+
+```dart
+WText(
+  'Body paragraph text with comfortable line height.',
+  className: 'text-base leading-normal text-gray-800 dark:text-gray-200',
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Multiplier | Description |
+|:------|:-----------|:------------|
+| `leading-3` | 0.75 | Compact |
+| `leading-4` | 1.0 | Standard compact |
+| `leading-5` | 1.25 | Slightly expanded |
+| `leading-6` | 1.5 | Comfortable |
+| `leading-7` | 1.75 | Spacious |
+| `leading-8` | 2.0 | Very spacious |
+| `leading-9` | 2.25 | Extra spacious |
+| `leading-10` | 2.5 | Maximum spaciousness |
+| `leading-none` | 1.0 | No extra spacing |
+| `leading-tight` | 1.25 | Tight spacing |
+| `leading-snug` | 1.375 | Snug spacing |
+| `leading-normal` | 1.5 | Normal spacing |
+| `leading-relaxed` | 1.625 | Relaxed spacing |
+| `leading-loose` | 2.0 | Loose spacing |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine with breakpoint prefixes to adjust line height per screen size:
+
+```dart
+WText('Body', className: 'leading-snug md:leading-normal lg:leading-relaxed');
+```
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Use bracket notation to set a precise multiplier not in the predefined scale:
+
+```dart
+WText('Custom line height', className: 'text-base leading-[1.3]');
+// 16px * 1.3 = 20.8px line height
+```
+
+<a name="customizing-theme"></a>
+## Customizing Theme
+
+Add or override line height keys with `WindTheme.setLineHeight(key, multiplier)`:
+
+```dart
+WindTheme.setLineHeight('comfortable', 1.6);
+WText('Custom leading', className: 'leading-comfortable');
+```
+
+See [Customizing Line Height](../customization/line-height.md) for full details.
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Size](font-size.md) — set text size.
+- [Letter Spacing](letter-spacing.md) — spacing between characters.
+- [Customizing Line Height](../customization/line-height.md) — override the default scale.

--- a/doc/typography/text-align.md
+++ b/doc/typography/text-align.md
@@ -1,0 +1,64 @@
+# Text Alignment
+
+Control the horizontal alignment of text content using predefined alignment classes.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/text_alignment" size="md" source="example/lib/pages/typography/text_alignment.dart"></x-preview>
+
+```dart
+WText('Left-aligned text', className: 'text-left');
+WText('Centered text', className: 'text-center');
+WText('Right-aligned text', className: 'text-right');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply text alignment with the `text-` prefix followed by an alignment direction:
+
+```dart
+WText(
+  'Centered heading',
+  className: 'text-center text-2xl font-bold text-gray-900 dark:text-gray-100',
+);
+WText(
+  'This paragraph text is justified for a formal appearance.',
+  className: 'text-justify text-base text-gray-700 dark:text-gray-300',
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Flutter `TextAlign` | Description |
+|:------|:--------------------|:------------|
+| `text-left` | `TextAlign.left` | Aligns text to the left. |
+| `text-center` | `TextAlign.center` | Centers the text. |
+| `text-right` | `TextAlign.right` | Aligns text to the right. |
+| `text-justify` | `TextAlign.justify` | Justifies the text. |
+| `text-start` | `TextAlign.start` | Aligns text to the reading direction start. |
+| `text-end` | `TextAlign.end` | Aligns text to the reading direction end. |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine with breakpoint prefixes to change alignment at different screen sizes:
+
+```dart
+WText(
+  'Responsive alignment',
+  className: 'text-center md:text-left',
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Size](font-size.md) — set text size.
+- [Font Weight](font-weight.md) — control text thickness.
+- [Text Color](text-color.md) — apply color to text.
+- [WText](../widgets/wtext.md) — the primary text widget.

--- a/doc/typography/text-color.md
+++ b/doc/typography/text-color.md
@@ -1,0 +1,90 @@
+# Text Color
+
+Apply color to text using predefined palette classes or arbitrary hex values.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Dark Mode](#dark-mode)
+- [Arbitrary Values](#arbitrary-values)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/text_color" size="md" source="example/lib/pages/typography/text_color.dart"></x-preview>
+
+```dart
+WText('Red text', className: 'text-red-500 dark:text-red-300');
+WText('Muted label', className: 'text-gray-500 dark:text-gray-400');
+WText('Custom color', className: 'text-[#1DA1F2]');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply text color with the `text-` prefix followed by a color name and shade:
+
+```dart
+WText(
+  'Primary heading',
+  className: 'text-gray-900 dark:text-gray-100 font-bold text-2xl',
+);
+WText(
+  'Supporting body text',
+  className: 'text-gray-600 dark:text-gray-400 text-base',
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+The full palette is available in every shade from 50 to 900. Use the pattern `text-{color}-{shade}`:
+
+| Pattern | Example class | Description |
+|:--------|:-------------|:------------|
+| `text-{color}` | `text-blue` | Color at default shade 500. |
+| `text-{color}-{shade}` | `text-blue-600` | Color at a specific shade (50–900). |
+| `text-[#rrggbb]` | `text-[#1DA1F2]` | Arbitrary hex color. |
+
+Available color names: `slate`, `gray`, `zinc`, `neutral`, `stone`, `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `black`, `white`, `primary`, `secondary`.
+
+Available shades: `50`, `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`.
+
+<a name="dark-mode"></a>
+## Dark Mode
+
+Wind automatically inverts color shades when dark mode is active. Add a `dark:` prefix variant to provide an explicit color for dark contexts:
+
+```dart
+WText(
+  'Adaptive text',
+  className: 'text-gray-900 dark:text-gray-100',
+);
+WText(
+  'Accent label',
+  className: 'text-blue-600 dark:text-blue-400',
+);
+WText(
+  'Error message',
+  className: 'text-red-600 dark:text-red-400',
+);
+```
+
+See [Dark Mode](../concepts/dark-mode.md) for how color inversion works.
+
+<a name="arbitrary-values"></a>
+## Arbitrary Values
+
+Set any color not in the predefined palette using a hex code in brackets:
+
+```dart
+WText('Brand color', className: 'text-[#1DA1F2]');
+WText('Custom pink', className: 'text-[#FF00FF]');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Text Decoration](text-decoration.md) — underline, overline, and strikethrough.
+- [Font Size](font-size.md) — set text size.
+- [Font Weight](font-weight.md) — control text thickness.
+- [Dark Mode](../concepts/dark-mode.md) — automatic color inversion.
+- [Customizing Colors](../customization/colors.md) — add or override palette colors.
+- [WText](../widgets/wtext.md) — the primary text widget.

--- a/doc/typography/text-decoration.md
+++ b/doc/typography/text-decoration.md
@@ -1,0 +1,59 @@
+# Text Decoration
+
+Apply underline, overline, or strikethrough decorations to text, or remove an inherited decoration.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/text_decoration" size="md" source="example/lib/pages/typography/text_decoration.dart"></x-preview>
+
+```dart
+WText('Underlined text', className: 'underline');
+WText('Strikethrough text', className: 'line-through');
+WText('No decoration', className: 'no-underline');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply decoration classes directly in the `className` of any text widget:
+
+```dart
+WText(
+  'See terms and conditions.',
+  className: 'underline text-blue-600 dark:text-blue-400',
+);
+WText(
+  'Original price: \$99',
+  className: 'line-through text-gray-500 dark:text-gray-400',
+);
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Flutter `TextDecoration` | Description |
+|:------|:-------------------------|:------------|
+| `no-underline` | `TextDecoration.none` | Removes any text decoration. |
+| `underline` | `TextDecoration.underline` | Adds an underline. |
+| `overline` | `TextDecoration.overline` | Adds an overline. |
+| `line-through` | `TextDecoration.lineThrough` | Adds a strikethrough. |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine with breakpoint prefixes to toggle decoration at certain screen sizes:
+
+```dart
+WText('Conditional underline', className: 'no-underline md:underline');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Text Color](text-color.md) — apply color to text.
+- [Font Style](font-style.md) — italic and normal styles.
+- [Font Weight](font-weight.md) — control text thickness.
+- [WText](../widgets/wtext.md) — the primary text widget.

--- a/doc/typography/text-transform.md
+++ b/doc/typography/text-transform.md
@@ -1,0 +1,55 @@
+# Text Transform
+
+Change the capitalization of text content at render time without modifying the source string.
+
+- [Basic Usage](#basic-usage)
+- [Quick Reference](#quick-reference)
+- [Responsive Design](#responsive-design)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="typography/text_transform" size="md" source="example/lib/pages/typography/text_transform.dart"></x-preview>
+
+```dart
+WText('upper case', className: 'uppercase');
+WText('LOWER CASE', className: 'lowercase');
+WText('capitalize this text', className: 'capitalize');
+WText('No transformation here.', className: 'none');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+Apply a transform class in the `className` of any text widget. The transformation runs at render time; the original `data` string is never mutated:
+
+```dart
+WText('button label', className: 'uppercase font-semibold text-white');
+WText('email@example.com', className: 'lowercase text-gray-700 dark:text-gray-300');
+WText('first word only', className: 'capitalize');
+```
+
+<a name="quick-reference"></a>
+## Quick Reference
+
+| Class | Transformation | Description |
+|:------|:---------------|:------------|
+| `uppercase` | `toUpperCase()` | Converts all characters to uppercase. |
+| `lowercase` | `toLowerCase()` | Converts all characters to lowercase. |
+| `capitalize` | First char upper, rest lower | Capitalizes the first character of the text. |
+| `none` | No change | Leaves the text unchanged. |
+
+<a name="responsive-design"></a>
+## Responsive Design
+
+Combine with breakpoint prefixes to apply a transform only at certain screen sizes:
+
+```dart
+WText('label text', className: 'none md:uppercase');
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+
+- [Font Size](font-size.md) — set text size.
+- [Text Color](text-color.md) — apply color to text.
+- [Text Decoration](text-decoration.md) — underline, overline, and strikethrough.
+- [WText](../widgets/wtext.md) — the primary text widget.

--- a/doc/widgets/wcard.md
+++ b/doc/widgets/wcard.md
@@ -1,0 +1,122 @@
+# WCard
+
+A utility-first card widget that wraps Flutter's `Card`, adding elevation, shadow, border, and padding through Wind className utilities.
+
+- [Basic Usage](#basic-usage)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Supported Utility Classes](#supported-utility-classes)
+- [Styling Examples](#styling-examples)
+- [WCard vs WContainer](#wcard-vs-wcontainer)
+- [Related Documentation](#related-documentation)
+
+```dart
+WCard(
+  className: 'bg-white shadow-lg rounded-lg p-4 dark:bg-gray-800',
+  child: WText('Card Content', className: 'text-gray-800 dark:text-gray-100'),
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WCard` wraps a single `child` and applies Wind utilities for background color, elevation/shadow, border, border radius, and padding. Use it when you want a card surface; for a plain styled box use [WContainer](wcontainer.md).
+
+```dart
+WCard(
+  className: 'bg-white shadow-lg rounded-lg p-4 dark:bg-gray-800',
+  child: WText('This is a card.', className: 'text-gray-800 dark:text-gray-100'),
+);
+```
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+WCard({
+  Key? key,
+  dynamic className = '',
+  Color? color,
+  Color? shadowColor,
+  Color? surfaceTintColor,
+  double? elevation,
+  ShapeBorder? shape,
+  bool borderOnForeground = true,
+  EdgeInsetsGeometry? margin,
+  Clip? clipBehavior,
+  Widget? child,
+  bool semanticContainer = true,
+});
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:---|:---|:---|:---|
+| `className` | `dynamic` | `''` | Wind utility class string applied to the card. |
+| `color` | `Color?` | `null` | Card background color; overrides any `bg-*` utility. |
+| `shadowColor` | `Color?` | `null` | Color of the drop shadow cast below the card. |
+| `surfaceTintColor` | `Color?` | `null` | Surface tint overlay color applied at elevation. |
+| `elevation` | `double?` | `null` | Card elevation; overrides any `shadow-*` utility. |
+| `shape` | `ShapeBorder?` | `null` | Card shape and border; overrides utility-driven border and radius. |
+| `borderOnForeground` | `bool` | `true` | Whether the shape border is painted in front of the child. |
+| `margin` | `EdgeInsetsGeometry?` | `null` | Outer margin; overrides any `m-*` utility. |
+| `clipBehavior` | `Clip?` | `null` | How the card content is clipped. |
+| `child` | `Widget?` | `null` | The single widget wrapped by the card. |
+| `semanticContainer` | `bool` | `true` | Whether the card is treated as a single semantic boundary. |
+
+<a name="supported-utility-classes"></a>
+## Supported Utility Classes
+
+| Class Type | Example | Documentation |
+|:---|:---|:---|
+| Responsive Design | `sm:p-4`, `xs:mt-2` | [Responsive Design](../concepts/responsive-design.md) |
+| Flex-x | `flex-1`, `flex-3` | [Flex-x](../flex/flex-x.md) |
+| Flex Fit Classes | `flex-grow`, `flex-auto` | [Flex Fit Classes](../flex/flex-fit.md) |
+| Alignment | `alignment-top-left` | [Alignment](../flex/alignment.md) |
+| Padding | `p-4`, `p-[11]` | [Padding](../spacing/padding.md) |
+| Margin | `m-8`, `m-[4]` | [Margin](../spacing/margin.md) |
+| Width | `w-10`, `w-[30]` | [Width](../sizing/width.md) |
+| Height | `h-10`, `h-[30]` | [Height](../sizing/height.md) |
+| Max-Width & Min-Width | `max-w-10`, `min-w-10` | [Max-Width & Min-Width](../sizing/max-width-min-width.md) |
+| Max-Height & Min-Height | `max-h-10`, `min-h-10` | [Max-Height & Min-Height](../sizing/max-height-min-height.md) |
+| Background Color | `bg-red-500`, `bg-green` | [Background Color](../backgrounds/background-color.md) |
+| Border Width | `border-4`, `border-[6]` | [Border Width](../borders/border-width.md) |
+| Border Color | `border-red-500`, `border-[#1abc9c]` | [Border Color](../borders/border-color.md) |
+| Border Radius | `rounded-lg`, `rounded-full` | [Border Radius](../borders/border-radius.md) |
+| Shadow | `shadow-sm`, `shadow-lg` | [Shadow](../effects/shadow.md) |
+| Display Classes | `hide`, `show`, `sm:hide` | [Display](../layout/display.md) |
+
+<a name="styling-examples"></a>
+## Styling Examples
+
+An elevated, padded card:
+
+```dart
+WCard(
+  className: 'bg-white shadow-lg rounded-lg p-4 dark:bg-gray-800',
+  child: WText('Elevated card', className: 'text-gray-800 dark:text-gray-100'),
+);
+```
+
+A bordered, flat card:
+
+```dart
+WCard(
+  className: 'bg-white border-2 border-gray-200 rounded-lg p-4 dark:bg-gray-900 dark:border-gray-700',
+  child: WText('Flat bordered card', className: 'text-gray-700 dark:text-gray-200'),
+);
+```
+
+<a name="wcard-vs-wcontainer"></a>
+## WCard vs WContainer
+
+`WCard` is purpose-built for cards: it exposes `elevation`, `shadowColor`, and `surfaceTintColor`, which `WContainer` does not. `WContainer` is a general-purpose styled box. Reach for `WContainer` when you need a plain styled container, and `WCard` when you need a card surface with elevation and shadow.
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [WContainer](wcontainer.md) — general-purpose styled box.
+- [WText](wtext.md) — utility-styled text for card children.
+- [Shadow](../effects/shadow.md) — shadow utilities used for elevation.
+- [Border Radius](../borders/border-radius.md) — corner rounding utilities.

--- a/doc/widgets/wcontainer.md
+++ b/doc/widgets/wcontainer.md
@@ -1,0 +1,124 @@
+# WContainer
+
+A utility-first container widget that wraps Flutter's `Container`, styled directly with Wind className utilities.
+
+- [Basic Usage](#basic-usage)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Supported Utility Classes](#supported-utility-classes)
+- [Styling Examples](#styling-examples)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="widgets/wcontainer" size="md" source="example/lib/pages/widgets/wcontainer.dart"></x-preview>
+
+```dart
+WContainer(
+  className: 'bg-gray-200 p-4 rounded-lg dark:bg-gray-800',
+  child: WText('This is a container', className: 'text-lg text-gray-700 dark:text-gray-200'),
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WContainer` is the Wind equivalent of an HTML `<div>`: a single-child box you style with utility classes. It wraps a single `child`; it does not lay out multiple children. For multi-child flex layouts reach for [WFlex](wflex.md) or [WFlexContainer](wflexcontainer.md).
+
+```dart
+WContainer(
+  className: 'bg-blue-500 p-4 rounded-lg shadow-md dark:bg-blue-700',
+  child: WText('This is a container', className: 'text-white text-lg'),
+);
+```
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+WContainer({
+  Key? key,
+  dynamic className = '',
+  AlignmentGeometry? alignment,
+  EdgeInsetsGeometry? padding,
+  Color? color,
+  Decoration? decoration,
+  Decoration? foregroundDecoration,
+  double? width,
+  double? height,
+  BoxConstraints? constraints,
+  EdgeInsetsGeometry? margin,
+  Matrix4? transform,
+  AlignmentGeometry? transformAlignment,
+  Widget? child,
+  Clip clipBehavior = Clip.none,
+});
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:---|:---|:---|:---|
+| `className` | `dynamic` | `''` | Wind utility class string applied to the container. |
+| `child` | `Widget?` | `null` | The single widget wrapped by the container. |
+| `alignment` | `AlignmentGeometry?` | `null` | Aligns the child within the container; overrides any `alignment-*` utility. |
+| `padding` | `EdgeInsetsGeometry?` | `null` | Inner padding; overrides any `p-*` utility. |
+| `color` | `Color?` | `null` | Background color; overrides any `bg-*` utility. |
+| `decoration` | `Decoration?` | `null` | Full box decoration; when set, overrides the utility-driven background, border, and shadow. |
+| `foregroundDecoration` | `Decoration?` | `null` | Decoration painted in front of the child. |
+| `width` | `double?` | `null` | Fixed width; overrides any `w-*` utility. |
+| `height` | `double?` | `null` | Fixed height; overrides any `h-*` utility. |
+| `constraints` | `BoxConstraints?` | `null` | Box constraints; overrides utility-driven min/max sizing. |
+| `margin` | `EdgeInsetsGeometry?` | `null` | Outer margin; overrides any `m-*` utility. |
+| `transform` | `Matrix4?` | `null` | Transformation matrix applied before painting. |
+| `transformAlignment` | `AlignmentGeometry?` | `null` | Origin of the `transform` relative to the container's size. |
+| `clipBehavior` | `Clip` | `Clip.none` | How content is clipped to the container bounds. |
+
+<a name="supported-utility-classes"></a>
+## Supported Utility Classes
+
+| Class Type | Example | Documentation |
+|:---|:---|:---|
+| Responsive Design | `sm:p-4`, `xs:mt-2` | [Responsive Design](../concepts/responsive-design.md) |
+| Flex-x | `flex-1`, `flex-3` | [Flex-x](../flex/flex-x.md) |
+| Flex Fit Classes | `flex-grow`, `flex-auto` | [Flex Fit Classes](../flex/flex-fit.md) |
+| Alignment | `alignment-top-left` | [Alignment](../flex/alignment.md) |
+| Padding | `p-4`, `p-[11]` | [Padding](../spacing/padding.md) |
+| Margin | `m-8`, `m-[4]` | [Margin](../spacing/margin.md) |
+| Width | `w-10`, `w-[30]` | [Width](../sizing/width.md) |
+| Height | `h-10`, `h-[30]` | [Height](../sizing/height.md) |
+| Max-Width & Min-Width | `max-w-10`, `min-w-10` | [Max-Width & Min-Width](../sizing/max-width-min-width.md) |
+| Max-Height & Min-Height | `max-h-10`, `min-h-10` | [Max-Height & Min-Height](../sizing/max-height-min-height.md) |
+| Background Color | `bg-red-500`, `bg-green` | [Background Color](../backgrounds/background-color.md) |
+| Border Width | `border-4`, `border-[6]` | [Border Width](../borders/border-width.md) |
+| Border Color | `border-red-500`, `border-[#1abc9c]` | [Border Color](../borders/border-color.md) |
+| Border Radius | `rounded-lg`, `rounded-full` | [Border Radius](../borders/border-radius.md) |
+| Shadow | `shadow-sm`, `shadow-lg` | [Shadow](../effects/shadow.md) |
+| Display Classes | `hide`, `show`, `sm:hide` | [Display](../layout/display.md) |
+
+<a name="styling-examples"></a>
+## Styling Examples
+
+A bordered, rounded card-like box:
+
+```dart
+WContainer(
+  className: 'bg-white border-2 border-gray-200 rounded-lg p-4 dark:bg-gray-900 dark:border-gray-700',
+  child: WText('Bordered box', className: 'text-gray-800 dark:text-gray-100'),
+);
+```
+
+A fixed-size, centered tile:
+
+```dart
+WContainer(
+  className: 'w-[120] h-[120] bg-blue-500 alignment-center rounded-lg',
+  child: WText('Centered', className: 'text-white'),
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [WCard](wcard.md) — card variant with elevation and shadow color.
+- [WFlex](wflex.md) — multi-child flex layout.
+- [WFlexContainer](wflexcontainer.md) — container and flex combined.
+- [WText](wtext.md) — utility-styled text for container children.

--- a/doc/widgets/wflex.md
+++ b/doc/widgets/wflex.md
@@ -1,0 +1,121 @@
+# WFlex
+
+A utility-first flex layout widget that wraps Flutter's `Flex`, controlling direction, alignment, spacing, and overflow through className utilities.
+
+- [Basic Usage](#basic-usage)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Supported Utility Classes](#supported-utility-classes)
+- [Styling Examples](#styling-examples)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="widgets/wflex" size="md" source="example/lib/pages/widgets/wflex.dart"></x-preview>
+
+```dart
+WFlex(
+  className: 'flex-col justify-center items-center gap-4',
+  children: [
+    WContainer(className: 'w-10 h-10 bg-blue-500'),
+    WContainer(className: 'w-10 h-10 bg-green-500'),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WFlex` is the Wind equivalent of an HTML `<div class="flex">`. It lays out a list of `children` along a main axis, controlling direction, justification, cross-axis alignment, gap spacing, and overflow with utility classes. When a Flutter `Flex` parameter is passed explicitly, it takes precedence over the matching utility class.
+
+```dart
+WFlex(
+  className: 'flex-row justify-center items-center gap-4',
+  children: [
+    WText('Child 1', className: 'text-red-500'),
+    WText('Child 2', className: 'text-blue-500'),
+  ],
+);
+```
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+WFlex({
+  Key? key,
+  dynamic className = '',
+  Axis? direction,
+  MainAxisAlignment? mainAxisAlignment,
+  MainAxisSize? mainAxisSize,
+  CrossAxisAlignment? crossAxisAlignment,
+  TextDirection? textDirection,
+  VerticalDirection verticalDirection = VerticalDirection.down,
+  TextBaseline? textBaseline,
+  Clip clipBehavior = Clip.none,
+  required List<Widget> children,
+});
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:---|:---|:---|:---|
+| `className` | `dynamic` | `''` | Wind utility class string applied to the flex layout. |
+| `children` | `List<Widget>` | **Required** | The widgets laid out along the main axis. |
+| `direction` | `Axis?` | `null` | Main-axis direction; overrides any `flex-row` / `flex-col` utility. |
+| `mainAxisAlignment` | `MainAxisAlignment?` | `null` | Main-axis alignment; overrides any `justify-*` utility. |
+| `mainAxisSize` | `MainAxisSize?` | `null` | Main-axis size; overrides any `axis-min` / `axis-max` utility. |
+| `crossAxisAlignment` | `CrossAxisAlignment?` | `null` | Cross-axis alignment; overrides any `items-*` utility. |
+| `textDirection` | `TextDirection?` | `null` | Text direction used to resolve `start` / `end` alignment. |
+| `verticalDirection` | `VerticalDirection` | `VerticalDirection.down` | Order in which children are laid out vertically. |
+| `textBaseline` | `TextBaseline?` | `null` | Baseline used when cross-axis alignment is baseline. |
+| `clipBehavior` | `Clip` | `Clip.none` | How overflowing content is clipped. |
+
+<a name="supported-utility-classes"></a>
+## Supported Utility Classes
+
+| Class Type | Example | Documentation |
+|:---|:---|:---|
+| Responsive Design | `sm:flex-row`, `xs:flex-col` | [Responsive Design](../concepts/responsive-design.md) |
+| Flex Direction | `flex-row`, `flex-col` | [Flex Direction](../flex/flex-direction.md) |
+| Justify Content | `justify-center`, `justify-start` | [Justify Content](../flex/justify-content.md) |
+| Align Items | `items-center`, `items-start` | [Align Items](../flex/align-items.md) |
+| Axis Sizes | `axis-max`, `axis-min` | [Axis Sizes](../flex/axis-sizes.md) |
+| Gap (Spacing) | `gap-2`, `gap-[4]` | [Gap (Spacing)](../flex/gap.md) |
+| Overflow | `overflow-scroll` | [Overflow](../layout/overflow.md) |
+| Display Classes | `hide`, `show`, `sm:hide` | [Display](../layout/display.md) |
+
+<a name="styling-examples"></a>
+## Styling Examples
+
+A spaced row of items:
+
+```dart
+WFlex(
+  className: 'flex-row justify-between items-center gap-2',
+  children: [
+    WText('Left', className: 'text-gray-700 dark:text-gray-200'),
+    WText('Right', className: 'text-gray-700 dark:text-gray-200'),
+  ],
+);
+```
+
+A scrollable column:
+
+```dart
+WFlex(
+  className: 'flex-col gap-4 overflow-scroll',
+  children: [
+    WContainer(className: 'w-full h-20 bg-blue-500'),
+    WContainer(className: 'w-full h-20 bg-green-500'),
+    WContainer(className: 'w-full h-20 bg-purple-500'),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [WFlexContainer](wflexcontainer.md) — combines a styled container with flex layout.
+- [WFlexible](wflexible.md) — flexible child sizing within a flex layout.
+- [WContainer](wcontainer.md) — single-child styled box.
+- [Flex Direction](../flex/flex-direction.md) — main-axis direction utilities.

--- a/doc/widgets/wflexcontainer.md
+++ b/doc/widgets/wflexcontainer.md
@@ -1,0 +1,162 @@
+# WFlexContainer
+
+A utility-first widget that combines a styled `WContainer` with a `WFlex` layout, letting you decorate a box and lay out its children in one className.
+
+- [Basic Usage](#basic-usage)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Supported Utility Classes](#supported-utility-classes)
+- [Styling Examples](#styling-examples)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="widgets/wflexcontainer" size="md" source="example/lib/pages/widgets/wflexcontainer.dart"></x-preview>
+
+```dart
+WFlexContainer(
+  className: 'flex-col items-center justify-center gap-4 bg-gray-200 dark:bg-gray-800',
+  children: [
+    WContainer(
+      className: 'w-16 h-16 bg-blue-500',
+      child: WText('Child 1', className: 'text-white'),
+    ),
+    WContainer(
+      className: 'w-16 h-16 bg-green-500',
+      child: WText('Child 2', className: 'text-white'),
+    ),
+  ],
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WFlexContainer` is a `WContainer` wrapping a `WFlex`, so it accepts both container styling utilities (background, border, padding, sizing) and flex layout utilities (direction, justify, align, gap) in the same className. It is the Wind equivalent of an HTML `<div class="flex ...">` that also carries box styling.
+
+```dart
+WFlexContainer(
+  className: 'flex-col justify-center items-center gap-4 bg-gray-200 dark:bg-gray-800',
+  children: [
+    WContainer(className: 'w-full h-10 bg-blue-500'),
+    WContainer(className: 'w-full h-10 bg-green-500'),
+  ],
+);
+```
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+WFlexContainer({
+  Key? key,
+  required List<Widget> children,
+  dynamic className = '',
+  AlignmentGeometry? alignment,
+  EdgeInsetsGeometry? padding,
+  Color? color,
+  Decoration? decoration,
+  Decoration? foregroundDecoration,
+  double? width,
+  double? height,
+  BoxConstraints? constraints,
+  EdgeInsetsGeometry? margin,
+  Matrix4? transform,
+  AlignmentGeometry? transformAlignment,
+  Clip clipBehavior = Clip.none,
+  Axis? direction,
+  MainAxisAlignment? mainAxisAlignment,
+  MainAxisSize? mainAxisSize,
+  CrossAxisAlignment? crossAxisAlignment,
+  TextDirection? textDirection,
+  VerticalDirection verticalDirection = VerticalDirection.down,
+  TextBaseline? textBaseline,
+});
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:---|:---|:---|:---|
+| `className` | `dynamic` | `''` | Wind utility class string applied to both the container and the flex layout. |
+| `children` | `List<Widget>` | **Required** | The widgets laid out along the main axis. |
+| `alignment` | `AlignmentGeometry?` | `null` | Container alignment; overrides utility-driven alignment. |
+| `padding` | `EdgeInsetsGeometry?` | `null` | Inner padding of the container. |
+| `color` | `Color?` | `null` | Container background color. |
+| `decoration` | `Decoration?` | `null` | Full box decoration for the container. |
+| `foregroundDecoration` | `Decoration?` | `null` | Decoration painted in front of the children. |
+| `width` | `double?` | `null` | Fixed container width. |
+| `height` | `double?` | `null` | Fixed container height. |
+| `constraints` | `BoxConstraints?` | `null` | Box constraints for the container. |
+| `margin` | `EdgeInsetsGeometry?` | `null` | Outer margin of the container. |
+| `transform` | `Matrix4?` | `null` | Transformation matrix applied to the container. |
+| `transformAlignment` | `AlignmentGeometry?` | `null` | Origin of the `transform`. |
+| `clipBehavior` | `Clip` | `Clip.none` | How content is clipped, applied to both container and flex. |
+| `direction` | `Axis?` | `null` | Main-axis direction; overrides any `flex-row` / `flex-col` utility. |
+| `mainAxisAlignment` | `MainAxisAlignment?` | `null` | Main-axis alignment; overrides any `justify-*` utility. |
+| `mainAxisSize` | `MainAxisSize?` | `null` | Main-axis size; overrides any `axis-*` utility. |
+| `crossAxisAlignment` | `CrossAxisAlignment?` | `null` | Cross-axis alignment; overrides any `items-*` utility. |
+| `textDirection` | `TextDirection?` | `null` | Text direction used to resolve `start` / `end` alignment. |
+| `verticalDirection` | `VerticalDirection` | `VerticalDirection.down` | Order in which children are laid out vertically. |
+| `textBaseline` | `TextBaseline?` | `null` | Baseline used when cross-axis alignment is baseline. |
+
+<a name="supported-utility-classes"></a>
+## Supported Utility Classes
+
+| Class Type | Example | Documentation |
+|:---|:---|:---|
+| Responsive Design | `sm:flex-col`, `xs:flex-row` | [Responsive Design](../concepts/responsive-design.md) |
+| Flex Direction | `flex-row`, `flex-col` | [Flex Direction](../flex/flex-direction.md) |
+| Justify Content | `justify-center`, `justify-between` | [Justify Content](../flex/justify-content.md) |
+| Align Items | `items-start`, `items-center` | [Align Items](../flex/align-items.md) |
+| Axis Sizes | `axis-max`, `axis-min` | [Axis Sizes](../flex/axis-sizes.md) |
+| Gap (Spacing) | `gap-2`, `gap-[4]` | [Gap (Spacing)](../flex/gap.md) |
+| Flex-x | `flex-1`, `flex-2` | [Flex-x](../flex/flex-x.md) |
+| Flex Fit Classes | `flex-grow`, `flex-auto` | [Flex Fit Classes](../flex/flex-fit.md) |
+| Alignment | `alignment-top-left`, `alignment-center-right` | [Alignment](../flex/alignment.md) |
+| Padding | `p-4`, `px-[6]`, `py-2` | [Padding](../spacing/padding.md) |
+| Margin | `m-8`, `mx-[4]`, `my-2` | [Margin](../spacing/margin.md) |
+| Width | `w-10`, `w-[30]` | [Width](../sizing/width.md) |
+| Height | `h-10`, `h-[30]` | [Height](../sizing/height.md) |
+| Max-Width & Min-Width | `max-w-10`, `min-w-[50]` | [Max-Width & Min-Width](../sizing/max-width-min-width.md) |
+| Max-Height & Min-Height | `max-h-10`, `min-h-[50]` | [Max-Height & Min-Height](../sizing/max-height-min-height.md) |
+| Background Color | `bg-red-500`, `bg-[#1abc9c]` | [Background Color](../backgrounds/background-color.md) |
+| Border Width | `border-4`, `border-[6]` | [Border Width](../borders/border-width.md) |
+| Border Color | `border-red-500`, `border-[#1abc9c]` | [Border Color](../borders/border-color.md) |
+| Border Radius | `rounded-lg`, `rounded-full` | [Border Radius](../borders/border-radius.md) |
+| Overflow | `overflow-scroll` | [Overflow](../layout/overflow.md) |
+| Shadow | `shadow-md`, `shadow-lg` | [Shadow](../effects/shadow.md) |
+| Display Classes | `hide`, `show`, `sm:hide` | [Display](../layout/display.md) |
+
+<a name="styling-examples"></a>
+## Styling Examples
+
+A padded, rounded panel with centered children:
+
+```dart
+WFlexContainer(
+  className: 'flex-col items-center gap-4 p-4 rounded-lg bg-white shadow-md dark:bg-gray-900',
+  children: [
+    WText('Title', className: 'text-lg font-bold text-gray-900 dark:text-white'),
+    WText('Subtitle', className: 'text-gray-600 dark:text-gray-300'),
+  ],
+);
+```
+
+A horizontal bar:
+
+```dart
+WFlexContainer(
+  className: 'flex-row justify-between items-center px-4 h-16 bg-gray-100 dark:bg-gray-800',
+  children: [
+    WText('Brand', className: 'font-bold text-gray-900 dark:text-white'),
+    WText('Menu', className: 'text-gray-600 dark:text-gray-300'),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [WFlex](wflex.md) — flex layout without container styling.
+- [WContainer](wcontainer.md) — styled box without flex layout.
+- [WFlexible](wflexible.md) — flexible child sizing within the layout.
+- [Justify Content](../flex/justify-content.md) — main-axis alignment utilities.

--- a/doc/widgets/wflexcontainer.md
+++ b/doc/widgets/wflexcontainer.md
@@ -93,7 +93,7 @@ WFlexContainer({
 | `clipBehavior` | `Clip` | `Clip.none` | How content is clipped, applied to both container and flex. |
 | `direction` | `Axis?` | `null` | Main-axis direction; overrides any `flex-row` / `flex-col` utility. |
 | `mainAxisAlignment` | `MainAxisAlignment?` | `null` | Main-axis alignment; overrides any `justify-*` utility. |
-| `mainAxisSize` | `MainAxisSize?` | `null` | Main-axis size; overrides any `axis-*` utility. |
+| `mainAxisSize` | `MainAxisSize?` | `null` | Main-axis size; overrides any `axis-min` / `axis-max` utility. |
 | `crossAxisAlignment` | `CrossAxisAlignment?` | `null` | Cross-axis alignment; overrides any `items-*` utility. |
 | `textDirection` | `TextDirection?` | `null` | Text direction used to resolve `start` / `end` alignment. |
 | `verticalDirection` | `VerticalDirection` | `VerticalDirection.down` | Order in which children are laid out vertically. |

--- a/doc/widgets/wflexible.md
+++ b/doc/widgets/wflexible.md
@@ -1,0 +1,102 @@
+# WFlexible
+
+A utility-first wrapper for Flutter's `Flexible` that controls flex factor and fit through className utilities; renders a `Spacer` when no child is given.
+
+- [Basic Usage](#basic-usage)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Supported Utility Classes](#supported-utility-classes)
+- [Styling Examples](#styling-examples)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="widgets/wflexible" size="md" source="example/lib/pages/widgets/wflexible.dart"></x-preview>
+
+```dart
+WFlexible(
+  className: 'flex-1 flex-grow',
+  child: WText('Flexible Child', className: 'text-blue-500 text-center'),
+);
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WFlexible` corresponds to the CSS `flex` property: place it inside a [WFlex](wflex.md) and use `flex-x` to set its flex factor and `flex-grow` / `flex-auto` / `flex-none` to set its fit. If `child` is omitted, `WFlexible` renders a `Spacer` with the resolved `flex` value, which is handy for flexible gaps and layout fillers. Visibility utilities such as `hide`, `show`, and `sm:hide` conditionally render the widget based on screen size.
+
+```dart
+WFlexible(
+  className: 'flex-1',
+  child: WText('Flexible Item'),
+);
+```
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+WFlexible({
+  Key? key,
+  dynamic className,
+  int? flex,
+  FlexFit? fit,
+  Widget? child,
+});
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:---|:---|:---|:---|
+| `className` | `dynamic` | `null` | Wind utility class string controlling flex factor and fit. |
+| `flex` | `int?` | `null` | Flex factor; overrides any `flex-x` utility. Falls back to `1` when neither is set. |
+| `fit` | `FlexFit?` | `null` | How the child fills available space; overrides any `flex-grow` / `flex-auto` / `flex-none` utility. Defaults to `FlexFit.loose` when unset. |
+| `child` | `Widget?` | `null` | The widget to make flexible. When omitted, a `Spacer` is rendered instead. |
+
+<a name="supported-utility-classes"></a>
+## Supported Utility Classes
+
+| Class Type | Example | Documentation |
+|:---|:---|:---|
+| Responsive Design | `sm:`, `xs:`, `md:` | [Responsive Design](../concepts/responsive-design.md) |
+| Flex-x | `flex-1`, `flex-2` | [Flex-x](../flex/flex-x.md) |
+| Flex Fit Classes | `flex-grow`, `flex-auto` | [Flex Fit Classes](../flex/flex-fit.md) |
+| Display Classes | `hide`, `show`, `sm:hide` | [Display](../layout/display.md) |
+
+<a name="styling-examples"></a>
+## Styling Examples
+
+A flexible item that grows to fill its row:
+
+```dart
+WFlex(
+  className: 'flex-row gap-2',
+  children: [
+    WContainer(className: 'w-16 bg-gray-300'),
+    WFlexible(
+      className: 'flex-1 flex-grow',
+      child: WContainer(className: 'bg-blue-500 h-10'),
+    ),
+  ],
+);
+```
+
+A spacer pushing items apart (no child):
+
+```dart
+WFlex(
+  className: 'flex-row',
+  children: [
+    WText('Left', className: 'text-gray-700 dark:text-gray-200'),
+    WFlexible(className: 'flex-1'),
+    WText('Right', className: 'text-gray-700 dark:text-gray-200'),
+  ],
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [WFlex](wflex.md) — the flex layout WFlexible lives inside.
+- [WFlexContainer](wflexcontainer.md) — styled container with flex layout.
+- [Flex-x](../flex/flex-x.md) — flex factor utilities.
+- [Flex Fit Classes](../flex/flex-fit.md) — flex fit utilities.

--- a/doc/widgets/wflexible.md
+++ b/doc/widgets/wflexible.md
@@ -49,7 +49,7 @@ WFlexible({
 | Prop | Type | Default | Description |
 |:---|:---|:---|:---|
 | `className` | `dynamic` | `null` | Wind utility class string controlling flex factor and fit. |
-| `flex` | `int?` | `null` | Flex factor; overrides any `flex-x` utility. Falls back to `1` when neither is set. |
+| `flex` | `int?` | `null` | Flex factor; overrides any `flex-x` utility. Falls back to `1` when neither the `flex` parameter nor a `flex-x` utility is set. |
 | `fit` | `FlexFit?` | `null` | How the child fills available space; overrides any `flex-grow` / `flex-auto` / `flex-none` utility. Defaults to `FlexFit.loose` when unset. |
 | `child` | `Widget?` | `null` | The widget to make flexible. When omitted, a `Spacer` is rendered instead. |
 

--- a/doc/widgets/wtext.md
+++ b/doc/widgets/wtext.md
@@ -1,0 +1,125 @@
+# WText
+
+A utility-first text widget that extends Flutter's `Text`, styling inline text through className utilities. The text content is passed as the first positional argument.
+
+- [Basic Usage](#basic-usage)
+- [Constructor](#constructor)
+- [Props](#props)
+- [Supported Utility Classes](#supported-utility-classes)
+- [Styling Examples](#styling-examples)
+- [Related Documentation](#related-documentation)
+
+<x-preview path="widgets/wtext" size="md" source="example/lib/pages/widgets/wtext.dart"></x-preview>
+
+```dart
+WText('Utility Styled Text', className: 'text-red-500 font-bold text-lg');
+```
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+`WText` is the Wind equivalent of an HTML `<span>`. The text content is the first positional argument; every other parameter is named. All Flutter `Text` parameters are available, and when a parameter conflicts with a utility class, the explicitly passed parameter wins. Pass `selectable` in the className to render a `SelectableText` instead.
+
+```dart
+WText(
+  'Styled Text',
+  className: 'text-red-500 font-bold text-lg underline truncate max-lines-2',
+);
+```
+
+<a name="constructor"></a>
+## Constructor
+
+```dart
+WText(
+  String data, {
+  dynamic className,
+  Key? key,
+  TextStyle? style,
+  StrutStyle? strutStyle,
+  TextAlign? textAlign,
+  TextDirection? textDirection,
+  Locale? locale,
+  bool? softWrap,
+  TextOverflow? overflow,
+  int? maxLines,
+  String? semanticsLabel,
+  TextWidthBasis? textWidthBasis,
+  TextHeightBehavior? textHeightBehavior,
+  Color? selectionColor,
+});
+```
+
+<a name="props"></a>
+## Props
+
+| Prop | Type | Default | Description |
+|:---|:---|:---|:---|
+| `data` | `String` | **Required** (positional) | The text content to render. First positional argument. |
+| `className` | `dynamic` | `null` | Wind utility class string applied to the text. |
+| `style` | `TextStyle?` | `null` | Explicit text style; merged over and overriding utility-driven styling. |
+| `strutStyle` | `StrutStyle?` | `null` | Strut style controlling minimum line height. |
+| `textAlign` | `TextAlign?` | `null` | Text alignment; overrides any `text-left` / `text-center` / `text-right` / `text-justify` utility. |
+| `textDirection` | `TextDirection?` | `null` | Direction in which the text flows. |
+| `locale` | `Locale?` | `null` | Locale used to select region-specific glyphs. |
+| `softWrap` | `bool?` | `null` | Whether the text wraps at soft line breaks; overrides overflow-derived wrapping. |
+| `overflow` | `TextOverflow?` | `null` | Overflow handling; overrides any `truncate` / `text-clip` / `text-fade` utility. |
+| `maxLines` | `int?` | `null` | Maximum number of lines; overrides any `max-lines-{n}` utility. |
+| `semanticsLabel` | `String?` | `null` | Alternative semantics label read by accessibility tools. |
+| `textWidthBasis` | `TextWidthBasis?` | `null` | How the text width is measured. |
+| `textHeightBehavior` | `TextHeightBehavior?` | `null` | How leading is applied to the first and last lines. |
+| `selectionColor` | `Color?` | `null` | Color of the selection highlight. |
+
+<a name="supported-utility-classes"></a>
+## Supported Utility Classes
+
+| Class Type | Example | Documentation |
+|:---|:---|:---|
+| Responsive Design | `sm:text-xl`, `xs:text-sm` | [Responsive Design](../concepts/responsive-design.md) |
+| Text Transform | `uppercase` | [Text Transform](../typography/text-transform.md) |
+| Text Color | `text-blue-400` | [Text Color](../typography/text-color.md) |
+| Font Weight | `font-bold` | [Font Weight](../typography/font-weight.md) |
+| Font Size | `text-lg`, `text-[18]` | [Font Size](../typography/font-size.md) |
+| Font Style | `italic` | [Font Style](../typography/font-style.md) |
+| Line Height | `leading-6`, `leading-[20]` | [Line Height](../typography/line-height.md) |
+| Text Decoration | `underline`, `line-through` | [Text Decoration](../typography/text-decoration.md) |
+| Letter Spacing | `tracking-wide`, `tracking-[4]` | [Letter Spacing](../typography/letter-spacing.md) |
+| Text Align | `text-center`, `text-justify` | [Text Align](../typography/text-align.md) |
+| Padding | `p-4`, `pb-[6]` | [Padding](../spacing/padding.md) |
+| Display Classes | `hide`, `show`, `sm:hide` | [Display](../layout/display.md) |
+
+<a name="styling-examples"></a>
+## Styling Examples
+
+Utility-styled text:
+
+```dart
+WText('Utility Styled Text', className: 'text-red-500 font-bold text-lg dark:text-red-400');
+```
+
+Using explicit parameters (overrides utility classes):
+
+```dart
+WText(
+  'Explicit Parameters',
+  className: 'text-red-500 font-bold text-lg',
+  // style overrides text-red-500 and font-bold
+  style: TextStyle(color: Colors.green, fontWeight: FontWeight.w300),
+);
+```
+
+Truncated, selectable text:
+
+```dart
+WText(
+  'A long line of selectable text that truncates after one line',
+  className: 'selectable truncate max-lines-1 text-gray-800 dark:text-gray-200',
+);
+```
+
+<a name="related-documentation"></a>
+## Related Documentation
+- [Text Color](../typography/text-color.md) — text color utilities.
+- [Font Size](../typography/font-size.md) — font size utilities.
+- [Text Align](../typography/text-align.md) — text alignment utilities.
+- [WContainer](wcontainer.md) — wrap text in a styled box.


### PR DESCRIPTION
## What

Adds an in-repo `doc/` reference to the frozen `0.0.x` line, porting the legacy site documentation (`wind.fluttersdk.com/resources/contents/docs/0.0.3`) into the 1.0.x doc-system format. 52 markdown files, mirroring the 0.0.3 topic taxonomy.

## Why

The 1.0.x line now keeps its docs in-repo under `doc/`. This brings the v0 line to the same shape so the website can sync v0 docs from the branch instead of a separate content store.

## Scope

Docs only. No source under `lib/` or `example/lib/` is touched. Content is faithful to the v0 API (static `WindTheme` class, widgets `WContainer`/`WCard`/`WFlex`/`WFlexContainer`/`WFlexible`/`WText`); format mirrors the master 1.0.x doc system (H1, ToC, anchors, `<x-preview>`, Props/Constructor for widgets, Related Documentation).

## Layout

- `getting-started/` (2), `concepts/` (4), `customization/` (9), `widgets/` (6)
- `typography/` (9), `flex/` (8), `spacing/` (2), `sizing/` (4)
- `backgrounds/` (1), `borders/` (3), `effects/` (1), `layout/` (2), `example/` (1)

## Guarantees

- No 1.0-only API leakage (`WDiv`, `WindThemeData`, builder pattern, `ring-`/`grid-cols`/`animate-`, `toggleTheme`).
- Every `<x-preview source>` resolves to a real `example/lib/pages/**` page on this branch; omitted (not faked) where no page exists (getting-started, customization, wcard, min/max sizing).
- All cross-doc links are relative `.md`; no absolute `wind.fluttersdk.com` URLs.
- Widget Constructor/Props tables read from the actual v0 component sources.
- v0 color shades 50-900 (no 950); barrel import `package:fluttersdk_wind/fluttersdk_wind.dart`.

## Follow-up (not in this PR)

- `lib/src/parsers/font_style.dart` has a trailing-tab typo in a map key (`'not-italic\t'`) that would stop the `not-italic` class from matching at runtime. Documented as `not-italic` here; worth a separate v0 source fix.