### PR TITLE
release: 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.5] - 2026-05-30
 
 ### Added
 - Add in-repo `doc/` reference for the 0.0.x line, ported from the legacy site docs into the 1.0.x doc-system format.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or manually add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fluttersdk_wind: ^0.0.4
+  fluttersdk_wind: ^0.0.5
 ```
 
 Then, fetch dependencies:

--- a/doc/getting-started/installation.md
+++ b/doc/getting-started/installation.md
@@ -29,7 +29,7 @@ Or add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  fluttersdk_wind: ^0.0.4
+  fluttersdk_wind: ^0.0.5
 ```
 
 Then run `flutter pub get`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: "A Flutter plugin designed with a utility-first approach, inspired by Tailwind CSS, for building responsive, modular, and efficient UI components."
-version: 0.0.4
+version: 0.0.5
 homepage: https://wind.fluttersdk.com
 
 environment:


### PR DESCRIPTION
## Release 0.0.5 (0.0.x legacy line)

Docs-only release: ships the in-repo `doc/` reference added in #91.

### Changes
- `pubspec.yaml`: `version: 0.0.4` -> `0.0.5`.
- `CHANGELOG.md`: promoted `## [Unreleased]` to `## [0.0.5] - 2026-05-30`.

No source code changed since 0.0.4; this release exists to publish the documentation set for the v0 line. Since 0.0.5 < 1.0.0, it does not affect the `latest` resolution on pub.dev (the 1.0.x line leads).

### Definition of done
- The release changeset touches only `pubspec.yaml` and `CHANGELOG.md`; no `.dart` files are modified, so it introduces no analyze or format regressions.
- `dart analyze` reports 5 pre-existing `info`-level items in v0 source (`avoid_print`, `Color.red/green/blue` deprecations) that also shipped in 0.0.4. Not addressed here: the v0 line is frozen for code changes and these are out of scope for a docs/version release.
- `dart format` would reformat ~31 pre-existing v0 source files (formatting drift predating this change). Not applied for the same reason. v0 has no CI analyze/format gate (only `publish.yml`, tag-triggered).
- No test suite exists on the v0 line.

### After merge
Tag and publish (maintainer step):
```bash
git tag 0.0.5 && git push origin 0.0.5   # triggers .github/workflows/publish.yml -> pub.dev
```