### PR TITLE
ci: auto-create GitHub Release on version tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,12 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
@@ -48,7 +50,7 @@ jobs:
     needs: validate
     permissions:
       id-token: write # Required for authentication using OIDC
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
 
   github-release:
     name: GitHub Release
@@ -58,20 +60,27 @@ jobs:
     permissions:
       contents: write # Required to create the GitHub Release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Extract changelog section
         id: notes
         env:
           VERSION: ${{ github.ref_name }}
         run: |
+          notes="$(awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+            flag && /^## / { exit }
+            flag { print }
+          ' CHANGELOG.md)"
+          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            echo "::error::No CHANGELOG.md section found for $VERSION; refusing to create a release with empty notes." >&2
+            exit 1
+          fi
           {
             echo 'body<<CHANGELOG_EOF'
-            awk -v ver="$VERSION" '
-              $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
-              flag && /^## / { exit }
-              flag { print }
-            ' CHANGELOG.md
+            printf '%s\n' "$notes"
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,3 +49,45 @@ jobs:
     permissions:
       id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+
+  github-release:
+    name: GitHub Release
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create the GitHub Release
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract changelog section
+        id: notes
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          {
+            echo 'body<<CHANGELOG_EOF'
+            awk -v ver="$VERSION" '
+              $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+              flag && /^## / { exit }
+              flag { print }
+            ' CHANGELOG.md
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+          NOTES: ${{ steps.notes.outputs.body }}
+        run: |
+          PRERELEASE=""
+          case "$VERSION" in
+            *-*) PRERELEASE="--prerelease" ;;
+            *) PRERELEASE="--latest" ;;
+          esac
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "$NOTES" \
+            --verify-tag \
+            $PRERELEASE


### PR DESCRIPTION
## Why

The `publish.yml` workflow publishes to pub.dev on a version-tag push but never created a GitHub Release. As a result `1.0.0` (and earlier `0.0.5`) shipped to pub.dev with no matching GitHub Release; the alpha releases were created by hand. This closes that gap so it cannot be forgotten again.

## What

- New `github-release` job, `needs: publish` and gated on `startsWith(github.ref, 'refs/tags/')`.
- Extracts the matching `## [VERSION]` section from `CHANGELOG.md` as release notes (stops at the next `## ` heading, so `### Added`/`### Fixed` subsections are included).
- Creates the release with `gh release create --verify-tag`. Tags with a hyphen (pre-releases) get `--prerelease`; stable tags get `--latest`.
- Scoped `contents: write` permission on the job only.

## Notes

- The missing `1.0.0` release was created manually as part of this work: https://github.com/fluttersdk/wind/releases/tag/1.0.0
- pub.dev `1.0.0` publish itself succeeded (run 27214539725); nothing was broken there.
- No `lib/` change, so the five-surface post-change sync does not apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release publishing process with automated GitHub release creation upon tag push, including proper changelog extraction and version classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->