### PR TITLE
feat(w_icon): add foregroundColor prop for runtime-dynamic icon colors (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `WIcon`: inline `foregroundColor` prop for runtime-dynamic icon colors. Overrides any `text-*` / `dark:text-*` from `className` and stays out of the parser cache key, matching `WText.foregroundColor`. (#103)
 - `WInput`: debug `AssertionError` when both `value` and `controller` are supplied simultaneously; passing both was always a logic error and previously led to silent precedence behavior (controller wins). The assert surfaces the misuse immediately in debug builds (W2).
 - `WInput`: `readOnly: true` now activates a `readonly` state, so `readonly:` prefixed classes style a read-only field just like `disabled:` does for a disabled one.
 

--- a/doc/widgets/w-icon.md
+++ b/doc/widgets/w-icon.md
@@ -65,15 +65,18 @@ const WIcon(
 Utility classes are for **design tokens** (`text-primary-500`, `text-red-500`). When the color is a **runtime value**, a category icon color from the database or a user-picked brand color, use the `foregroundColor` prop instead of interpolating into `text-[#$hex]`.
 
 ```dart
+// `category.color` is a Color loaded at runtime (e.g. from the database).
+
 // Good: runtime-dynamic color via inline prop
 WIcon(
-  LucideIcons.star,
+  Icons.star,
   foregroundColor: category.color,
   className: 'text-lg',
 )
 
-// Avoid: string interpolation bloats the parser cache, one entry per unique hex
-WIcon(LucideIcons.star, className: 'text-lg text-[#${category.color.hex}]')
+// Avoid: interpolating a runtime value into className bloats the parser
+// cache with one entry per unique color (`categoryHex` is a String like 'ff5500')
+WIcon(Icons.star, className: 'text-lg text-[#$categoryHex]')
 ```
 
 Precedence: inline `foregroundColor` wins over any `text-*` / `dark:text-*` resolved from `className`. When `foregroundColor` is `null`, className behavior, including the `dark:` fallback, is unchanged. The inline color does not participate in the parser cache key.

--- a/doc/widgets/w-icon.md
+++ b/doc/widgets/w-icon.md
@@ -5,6 +5,7 @@ The utility-first icon component for displaying vector icons with Tailwind-like 
 - [Basic Usage](#basic-usage)
 - [Constructor](#constructor)
 - [Props](#props)
+- [Runtime-Dynamic Colors](#runtime-dynamic-colors)
 - [Layout Modes](#layout-modes)
 - [Event Handling](#event-handling)
 - [State Variants](#state-variants)
@@ -41,6 +42,7 @@ const WIcon(
   Key? key,
   String? className,
   Set<String>? states,
+  Color? foregroundColor,
   String? semanticLabel,
   TextDirection? textDirection,
 })
@@ -53,8 +55,28 @@ const WIcon(
 | `icon` | `IconData` | **Required** | The icon to display. |
 | `className` | `String?` | `null` | Wind utility classes for styling. |
 | `states` | `Set<String>?` | `null` | Custom states to activate prefix classes. |
+| `foregroundColor` | `Color?` | `null` | Inline icon color for runtime-dynamic values. Overrides any `text-*` / `dark:text-*` from `className`. See [Runtime-Dynamic Colors](#runtime-dynamic-colors). |
 | `semanticLabel` | `String?` | `null` | Optional semantic label for accessibility. |
 | `textDirection` | `TextDirection?` | `null` | Text direction for the icon. |
+
+<a name="runtime-dynamic-colors"></a>
+## Runtime-Dynamic Colors
+
+Utility classes are for **design tokens** (`text-primary-500`, `text-red-500`). When the color is a **runtime value**, a category icon color from the database or a user-picked brand color, use the `foregroundColor` prop instead of interpolating into `text-[#$hex]`.
+
+```dart
+// Good: runtime-dynamic color via inline prop
+WIcon(
+  LucideIcons.star,
+  foregroundColor: category.color,
+  className: 'text-lg',
+)
+
+// Avoid: string interpolation bloats the parser cache, one entry per unique hex
+WIcon(LucideIcons.star, className: 'text-lg text-[#${category.color.hex}]')
+```
+
+Precedence: inline `foregroundColor` wins over any `text-*` / `dark:text-*` resolved from `className`. When `foregroundColor` is `null`, className behavior, including the `dark:` fallback, is unchanged. The inline color does not participate in the parser cache key.
 
 ## Layout Modes
 

--- a/example/lib/pages/icons/icon_basic.dart
+++ b/example/lib/pages/icons/icon_basic.dart
@@ -3,11 +3,35 @@ import 'package:fluttersdk_wind/fluttersdk_wind.dart';
 
 import '../../widgets/example_scaffold.dart';
 
-class IconBasicExamplePage extends StatelessWidget {
+/// Demonstrates WIcon: className-driven sizing and tinting, animations,
+/// opacity modifiers, and runtime-dynamic foregroundColor for values that
+/// cannot be expressed as a static text-{color} token.
+class IconBasicExamplePage extends StatefulWidget {
   const IconBasicExamplePage({super.key});
 
   @override
+  State<IconBasicExamplePage> createState() => _IconBasicExamplePageState();
+}
+
+class _IconBasicExamplePageState extends State<IconBasicExamplePage> {
+  // Simulates per-category colors coming from a database or runtime config.
+  // Using foregroundColor avoids creating a new parser-cache entry per value.
+  static const List<(String, Color)> _categoryPalette = <(String, Color)>[
+    ('Work', Color(0xFF3B82F6)),
+    ('Personal', Color(0xFF10B981)),
+    ('Urgent', Color(0xFFEF4444)),
+    ('Shopping', Color(0xFFF59E0B)),
+    ('Travel', Color(0xFF8B5CF6)),
+  ];
+  int _categoryIndex = 0;
+
+  (String, Color) get _activeCategory =>
+      _categoryPalette[_categoryIndex % _categoryPalette.length];
+
+  @override
   Widget build(BuildContext context) {
+    final (categoryName, categoryColor) = _activeCategory;
+
     return ExampleScaffold(
       title: 'WIcon',
       description:
@@ -93,6 +117,58 @@ class IconBasicExamplePage extends StatelessWidget {
                 hover:rotate-180
               ''',
             ),
+          ),
+        ),
+        ExampleSection(
+          title: 'Runtime-Dynamic Color',
+          description:
+              'Use foregroundColor for values unknown at compile time (per-category colors, user themes). '
+              'The className keeps text-{size} for sizing; foregroundColor overrides the tint at runtime '
+              'without creating a new parser-cache entry per value.',
+          child: WDiv(
+            className:
+                'flex flex-col gap-4 p-4 bg-gray-50 dark:bg-slate-800 rounded-lg',
+            children: [
+              WDiv(
+                className: 'flex flex-row items-center gap-4',
+                children: [
+                  WIcon(
+                    Icons.label,
+                    className: 'text-4xl',
+                    foregroundColor: categoryColor,
+                  ),
+                  WDiv(
+                    className: 'flex flex-col gap-1',
+                    children: [
+                      WText(
+                        categoryName,
+                        className:
+                            'text-base font-semibold text-gray-900 dark:text-white',
+                      ),
+                      WText(
+                        '#${categoryColor.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toUpperCase()}',
+                        className:
+                            'text-xs font-mono text-gray-500 dark:text-gray-400',
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              WAnchor(
+                onTap: () => setState(
+                  () => _categoryIndex =
+                      (_categoryIndex + 1) % _categoryPalette.length,
+                ),
+                child: const WDiv(
+                  className:
+                      'px-3 py-2 rounded-md bg-blue-500 hover:bg-blue-600',
+                  child: WText(
+                    'Cycle category color',
+                    className: 'text-white text-sm font-medium',
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ],

--- a/lib/src/widgets/w_icon.dart
+++ b/lib/src/widgets/w_icon.dart
@@ -46,6 +46,17 @@ class WIcon extends StatelessWidget {
   /// Example: `states: {'hover'}` activates `hover:text-red-500`.
   final Set<String>? states;
 
+  /// Inline icon color for **runtime-dynamic** values (e.g. a status color
+  /// resolved at runtime from a server response or user preference).
+  ///
+  /// Use `className: 'text-*'` for static design tokens. Reach for this prop
+  /// only when the color is a runtime value that would otherwise bloat the
+  /// parser cache via `text-[#\$hex]` interpolation.
+  ///
+  /// When non-null, this overrides any `text-*` / `dark:text-*` resolved
+  /// from [className]. Does NOT participate in the parser cache key.
+  final Color? foregroundColor;
+
   /// Optional semantic label for accessibility.
   final String? semanticLabel;
 
@@ -58,6 +69,7 @@ class WIcon extends StatelessWidget {
     super.key,
     this.className,
     this.states,
+    this.foregroundColor,
     this.semanticLabel,
     this.textDirection,
   });
@@ -69,12 +81,12 @@ class WIcon extends StatelessWidget {
     final double? inheritedSize = inheritedStyle.fontSize;
     final Color? inheritedColor = inheritedStyle.color;
 
-    // If no className, use inherited values
+    // If no className, use foregroundColor if provided, else inherited values.
     if (className == null) {
       return Icon(
         icon,
         size: inheritedSize,
-        color: inheritedColor,
+        color: foregroundColor ?? inheritedColor,
         semanticLabel: semanticLabel,
         textDirection: textDirection,
       );
@@ -91,8 +103,8 @@ class WIcon extends StatelessWidget {
     final double? size =
         styles.width ?? styles.height ?? styles.fontSize ?? inheritedSize;
 
-    // Determine color: className color > inherited color
-    final Color? color = styles.color ?? inheritedColor;
+    // Determine color: foregroundColor > className color > inherited color.
+    final Color? color = foregroundColor ?? styles.color ?? inheritedColor;
 
     Widget iconWidget = Icon(
       icon,

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -3,10 +3,10 @@ name: wind-ui
 description: "fluttersdk_wind 1.0: utility-first Flutter styling with Tailwind-syntax className strings. 22 public widgets (WDiv, WText, WButton, WInput, WSelect, WCheckbox, WDatePicker, WPopover, WAnchor, WIcon, WImage, WSvg, WSpacer, WBreakpoint, WDynamic, WKeyboardActions, WindAnimationWrapper + 5 WForm* wrappers) consume className through a 19-parser pipeline (19 implementation files organized into 12 token families for teaching) that emits a cached immutable WindStyle. Prefixes stack freely (dark: / hover: / focus: / md: / lg: / ios: / android: / web: / mobile: / selected: / loading: / disabled: / error: / checked: / custom). Last class wins; unknown tokens fail silently. Every color token (bg-, text-, border-, ring-, shadow-, fill-) needs a dark: pair in the same className. TRIGGER when: writing or editing any UI in a Flutter app that depends on `fluttersdk_wind`; any className string; any W-prefix widget; any WindTheme / WindThemeData reference; the user mentions Tailwind for Flutter, utility-first, className, or wind-ui. DO NOT TRIGGER when: backend / API / state-management work that does not touch a widget tree; Flutter projects that do not have fluttersdk_wind in pubspec.yaml; Material-only widgets (Scaffold, AppBar, Dialog) without Wind content inside them."
 when_to_use: |
   Any task that produces, modifies, or audits Wind-styled Flutter UI: composing a className string, picking the right W-widget for a use case, integrating with a Form / FormField, customizing WindThemeData, wiring dark-mode pairs, debugging an unexpected layout, recovering from RenderFlex overflow, building a popover or dropdown, rendering a JSON tree via WDynamic, wiring Wind.installDebugResolver for kDebugMode tooling, or migrating a Tailwind className from web. Apply BEFORE writing the first line of UI in a Wind-using file, not as an audit pass.
-version: 2.2.0
+version: 2.3.0
 ---
 
-<!-- fluttersdk_wind 1.0.x | Skill v2.2.0 (2026-06-16) -->
+<!-- fluttersdk_wind 1.0.x | Skill v2.3.0 (2026-06-16) -->
 
 # Wind UI 1.0
 
@@ -76,7 +76,7 @@ The headline 20 (table below) are the ones an agent reaches for daily. Two more 
 | `WSpacer` | Layout | none | Lightweight `SizedBox` that reads only `w-N` / `h-N`. Skips every other token. |
 | `WBreakpoint` | Structural | none | Per-breakpoint `WidgetBuilder` map (`base`, `sm`, `md`, `lg`, `xl`, `xxl`, plus theme-defined custom keys). Escape hatch when className prefixes are not enough. |
 | `WText` | Display | `data: String` | Typography; supports `selectable` prop. Inline color prop: `foregroundColor`. No `child` / `children`. |
-| `WIcon` | Display | `icon: IconData` | Material icons; use `Icons.*_outlined` variants by convention. Reads `text-*` for size AND color (overloaded). Inherits from `DefaultTextStyle` when className is absent. |
+| `WIcon` | Display | `icon: IconData` | Material icons; use `Icons.*_outlined` variants by convention. Reads `text-*` for size AND color (overloaded). Inherits from `DefaultTextStyle` when className is absent. Inline color prop: `foregroundColor`. |
 | `WImage` | Display | none (requires `src` or `image`) | Network (URL) or asset (prefix `asset://path`) or `ImageProvider`. `object-cover` default. |
 | `WSvg` / `WSvg.string` | Display | `src` / `svg` | Vector graphics. `fill-*` / `stroke-*` for color. `preserve-colors` token disables tint for multi-color SVGs (QR codes, logos). |
 | `WAnchor` | Interactive | `child: Widget` | Low-level gesture + focus + hover propagator. Emits `Semantics(button: true)`. |

--- a/skills/wind-ui/references/tailwind-divergence.md
+++ b/skills/wind-ui/references/tailwind-divergence.md
@@ -167,7 +167,7 @@ Wind adds a small set of tokens for Flutter-specific scenarios.
 ### Inline color escape hatches (bypass cache key for runtime-dynamic colors)
 - `WDiv(backgroundColor: Color)` — Dart prop, overrides className `bg-*`
 - `WText(foregroundColor: Color)` — Dart prop, overrides className `text-*`
-- `WIcon(foregroundColor: Color)`, Dart prop, overrides className `text-*`
+- `WIcon(foregroundColor: Color)` (Dart prop) overrides className `text-*`
 
 ### Per-breakpoint widget builders
 - `WBreakpoint(base: ..., sm: ..., md: ...)` — when className prefixes cannot express the change

--- a/skills/wind-ui/references/tailwind-divergence.md
+++ b/skills/wind-ui/references/tailwind-divergence.md
@@ -167,6 +167,7 @@ Wind adds a small set of tokens for Flutter-specific scenarios.
 ### Inline color escape hatches (bypass cache key for runtime-dynamic colors)
 - `WDiv(backgroundColor: Color)` — Dart prop, overrides className `bg-*`
 - `WText(foregroundColor: Color)` — Dart prop, overrides className `text-*`
+- `WIcon(foregroundColor: Color)`, Dart prop, overrides className `text-*`
 
 ### Per-breakpoint widget builders
 - `WBreakpoint(base: ..., sm: ..., md: ...)` — when className prefixes cannot express the change

--- a/skills/wind-ui/references/tokens.md
+++ b/skills/wind-ui/references/tokens.md
@@ -45,6 +45,7 @@ Resolution:
 Inline color escape hatches that bypass the cache key:
 - `WDiv(backgroundColor: Color)` overrides any `bg-*` / `dark:bg-*`.
 - `WText(foregroundColor: Color)` overrides any `text-*` / `dark:text-*`.
+- `WIcon(foregroundColor: Color)` overrides any `text-*` / `dark:text-*`.
 
 ---
 

--- a/test/widgets/w_icon_test.dart
+++ b/test/widgets/w_icon_test.dart
@@ -13,6 +13,73 @@ Widget wrapWithTheme(Widget child) {
 
 void main() {
   group('WIcon Widget Tests', () {
+    setUp(() {
+      WindParser.clearCache();
+    });
+
+    group('Inline foregroundColor', () {
+      testWidgets('applies foregroundColor when className has no color class',
+          (tester) async {
+        const color = Color(0xFF112233);
+        await tester.pumpWidget(
+          wrapWithTheme(
+            const WIcon(Icons.star,
+                className: 'text-lg', foregroundColor: color),
+          ),
+        );
+
+        final icon = tester.widget<Icon>(find.byType(Icon));
+        expect(icon.color, color);
+      });
+
+      testWidgets('foregroundColor wins over text-red-500 in className',
+          (tester) async {
+        const override = Color(0xFFCC00CC);
+        await tester.pumpWidget(
+          wrapWithTheme(
+            const WIcon(
+              Icons.star,
+              className: 'text-red-500',
+              foregroundColor: override,
+            ),
+          ),
+        );
+
+        final icon = tester.widget<Icon>(find.byType(Icon));
+        expect(icon.color, override);
+      });
+
+      testWidgets(
+          'parser cache entry is shared across WIcons with different '
+          'foregroundColor but identical className', (tester) async {
+        const sameClass = 'text-lg';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WindTheme(
+              data: WindThemeData(),
+              child: const Column(
+                children: [
+                  WIcon(
+                    Icons.star,
+                    className: sameClass,
+                    foregroundColor: Color(0xFF111111),
+                  ),
+                  WIcon(
+                    Icons.star,
+                    className: sameClass,
+                    foregroundColor: Color(0xFF222222),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(WindParser.cacheSize, 1);
+      });
+    });
+
     group('Basic Rendering', () {
       testWidgets('renders icon without className', (tester) async {
         await tester.pumpWidget(wrapWithTheme(const WIcon(Icons.star)));


### PR DESCRIPTION
## Summary

Adds an inline `Color? foregroundColor` prop to `WIcon` for runtime-dynamic icon colors, mirroring the existing `WText.foregroundColor` / `WDiv.backgroundColor` escape hatch (#59).

Closes #103.

## Why

`className` is a compile-time string and cannot carry a runtime `Color` (a user-selected accent, a per-category color from the database). The only workaround was dropping to native `Icon()` (losing className-driven sizing) or `text-[#$hex]` interpolation (one parser-cache entry per unique hex). `WIcon` was the last of the three core components still missing the inline-color escape hatch.

```dart
// Now a one-liner:
WIcon(LucideIcons.star, className: 'text-lg', foregroundColor: category.color)
```

## Change

- `WIcon.foregroundColor: Color?` applied as the highest-priority color in BOTH build paths: the `className == null` early return (`foregroundColor ?? inheritedColor`) and the parsed path (`foregroundColor ?? styles.color ?? inheritedColor`). It overrides any `text-*` / `dark:text-*` resolved from `className` and the inherited `DefaultTextStyle` color.
- Does NOT participate in the parser cache key: two `WIcon`s with identical `className` but different `foregroundColor` share one cache entry.
- No baseline-color fallback (Flutter's `Icon` accepts `color: null` and resolves via `IconTheme`); opacity/animation wrappers untouched.
- 3-part dartdoc matching the `WText.foregroundColor` precedent.

## Tests

- `foregroundColor` applies when `className` has no color class.
- `foregroundColor` wins over `text-red-500`.
- Cache-key invariant: identical `className` + different `foregroundColor` keeps `WindParser.cacheSize == 1`.
- Also added the previously-missing `WindParser.clearCache()` `setUp` to the WIcon test file (test-hygiene fix required by `.claude/rules/tests.md`).

## Five-surface sync

- `doc/widgets/w-icon.md`: Props row + Constructor + new "Runtime-Dynamic Colors" section.
- `example/lib/pages/icons/icon_basic.dart`: interactive runtime-color demo (cycles per-category colors via `foregroundColor`).
- `skills/wind-ui/`: SKILL WIcon row + version bump 2.2.0 -> 2.3.0; `tailwind-divergence.md` and `tokens.md` escape-hatch lists.
- `CHANGELOG.md`: `[Unreleased]` > Added.
- `README.md`: intentionally unchanged (inline-prop addition is not overview-worthy; the 22-widget roster is unchanged).

## Out of scope

- WDynamic JSON renderer support: JSON has no runtime-`Color` channel; a hex->Color renderer enhancement is a separate feature with its own schema/security review.

## Verification

- `dart format --set-exit-if-changed .`: clean.
- `dart analyze`: zero issues.
- `flutter test`: 1409 pass, 1 pre-existing skip, 0 failures.
- `./tool/coverage.sh 90`: 91.1%.
- `cd example && flutter build web`: succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `WIcon` now supports runtime-dynamic icon colors via a new optional `foregroundColor` prop. This prop takes precedence over color utilities specified in `className`, allowing for flexible color control at runtime.

* **Documentation**
  * Enhanced documentation with new "Runtime-Dynamic Colors" section, practical examples, and reference documentation explaining the new `foregroundColor` capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->