### PR TITLE
feat: className alias support in WindThemeData (#104)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ lib/src/
 │   └── parsers/              # 19 domain parsers (see .claude/rules/parsers.md)
 ├── theme/
 │   ├── wind_theme.dart       # WindTheme StatefulWidget + WindThemeController
-│   ├── wind_theme_data.dart  # 23 configurable fields; merges with defaults/
+│   ├── wind_theme_data.dart  # 24 configurable fields; merges with defaults/
 │   └── defaults/             # 16 default token scales
 ├── dynamic/          # WDynamic JSON renderer (see .claude/rules/dynamic.md)
 ├── state/            # WindAnchorStateProvider (hover/focus/press via InheritedWidget)
@@ -48,7 +48,7 @@ Wrap the app once at the top:
 
 ```dart
 WindTheme(
-  data: WindThemeData(/* 23 fields, all optional, merged with defaults */),
+  data: WindThemeData(/* 24 fields, all optional, merged with defaults */),
   builder: (context, controller) => MaterialApp(
     theme: controller.toThemeData(),
     home: ...,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `WindThemeData.aliases` (`Map<String, String>`, empty by default): bare-token recursive className shortcuts expanded centrally in `WindParser.parse` before the 19-parser pipeline runs, so they work in every widget and in `WDynamic` without additional wiring. An alias that shadows a real token wins and emits a debug warning. Resolves the `#101` class of silent unknown-token failures caused by shorthand tokens not being in the default token catalog. (#104)
 - `WIcon`: inline `foregroundColor` prop for runtime-dynamic icon colors. Overrides any `text-*` / `dark:text-*` from `className` and stays out of the parser cache key, matching `WText.foregroundColor`. (#103)
 - `WInput`: debug `AssertionError` when both `value` and `controller` are supplied simultaneously; passing both was always a logic error and previously led to silent precedence behavior (controller wins). The assert surfaces the misuse immediately in debug builds (W2).
 - `WInput`: `readOnly: true` now activates a `readonly` state, so `readonly:` prefixed classes style a read-only field just like `disabled:` does for a disabled one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ When source under `lib/` changes, the agent updates each of these in the same ch
 
 - Update only when the change is overview-worthy: a new widget added to the public roster, a new top-level feature (theme field, parser token family, integration entry point), a public API addition or removal.
 - Internal refactors, test additions, doc fixes, dependency tweaks: NO README update needed — the noise harms more than the precision helps.
-- Acceptance: README's "What you get" / "The Wind Surface" sections reflect the v1 roster (22 widgets, 19 parsers, 23 theme fields) accurately.
+- Acceptance: README's "What you get" / "The Wind Surface" sections reflect the v1 roster (22 widgets, 19 parsers, 24 theme fields) accurately.
 
 **One change set, all five surfaces.** Do not split "code now, docs later" — the next session loses context and the docs rot.
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@
 flutter pub add fluttersdk_wind
 ```
 
-Wrap your app in `WindTheme`, then write `className` strings. The full setup walkthrough, all 22 widgets, every parser token, the 23 theme fields, and the three AI integration layers live at the [Getting Started guide](https://fluttersdk.com/wind/getting-started/installation).
+Wrap your app in `WindTheme`, then write `className` strings. The full setup walkthrough, all 22 widgets, every parser token, the 24 theme fields, and the three AI integration layers live at the [Getting Started guide](https://fluttersdk.com/wind/getting-started/installation).
 
 ## Why Wind?
 
 Do you like using Tailwind CSS to style your UIs? **This helps you do that in Flutter.**
 
-Wind is **not** a widget library. It is a utility-first styling engine that maps Tailwind-syntax `className` strings to optimized Flutter widget trees, with a 23-field theme, 19 parsers, and 22 W-prefix widgets. Flutter's structural styling produces six-widget pyramids for a rounded card with a hover state. The Flutter team itself acknowledged the [verbosity pain](https://github.com/flutter/flutter/issues/161345), ran an experimental Decorators feature, found mixed results, and shelved it. Wind closes that gap.
+Wind is **not** a widget library. It is a utility-first styling engine that maps Tailwind-syntax `className` strings to optimized Flutter widget trees, with a 24-field theme, 19 parsers, and 22 W-prefix widgets. Flutter's structural styling produces six-widget pyramids for a rounded card with a hover state. The Flutter team itself acknowledged the [verbosity pain](https://github.com/flutter/flutter/issues/161345), ran an experimental Decorators feature, found mixed results, and shelved it. Wind closes that gap.
 
 ```dart
 // Before: Flutter native (15 lines)
@@ -82,7 +82,7 @@ WDiv(
 | 🌙 | **First-class dark mode** | `dark:` prefix with runtime toggle and automatic system-brightness sync. Every color token carries its `dark:` pair in the same className. |
 | 🎯 | **State prefixes** | `hover:`, `focus:`, `disabled:`, `loading:`, `selected:`, and any custom state. Zero `MouseRegion`, zero `setState`, zero `_isHovered` booleans. |
 | 🔌 | **Platform prefixes** | `ios:`, `android:`, `web:`, `mobile:` for conditional styling without a single `if`. Works on all 6 Flutter platforms. |
-| 🎭 | **Customizable theme** | 23 configurable `WindThemeData` fields. Override every token scale: colors, spacing, typography, shadows, breakpoints, animations. Defaults match Tailwind v3 / v4. |
+| 🎭 | **Customizable theme** | 24 configurable `WindThemeData` fields. Override every token scale: colors, spacing, typography, shadows, breakpoints, animations. Defaults match Tailwind v3 / v4. Define `aliases` to create bare-token className shortcuts expanded before parsing. |
 | 📡 | **Server-driven UI** | `WDynamic` renders widget trees from JSON. Ship UI updates without ship-blocking releases. Whitelisted 13 Wind widgets + 16 Flutter core widgets. |
 | 🤖 | **AI-first** | Canonical `wind-ui` skill at `skills/wind-ui/` and a hosted MCP server at `mcp.fluttersdk.com`, distributed to 8+ agents (Claude Code, Cursor, OpenCode, Gemini CLI, VS Code Copilot, Codex CLI, Cline, Roo Code) via [fluttersdk/ai](https://github.com/fluttersdk/ai). No other Flutter styling library ships this. |
 
@@ -130,7 +130,7 @@ WDiv(
 
 ## Documentation
 
-Full docs with live examples at **[fluttersdk.com/wind](https://fluttersdk.com/wind)**: every widget, every parser token, the 23 theme fields, dark mode, responsive design, server-driven UI via `WDynamic`, and the AI integration setup. The internal architecture lives in [`ARCHITECTURE.md`](ARCHITECTURE.md). The LLM-readable inventory lives in [`llms.txt`](llms.txt).
+Full docs with live examples at **[fluttersdk.com/wind](https://fluttersdk.com/wind)**: every widget, every parser token, the 24 theme fields, dark mode, responsive design, server-driven UI via `WDynamic`, and the AI integration setup. The internal architecture lives in [`ARCHITECTURE.md`](ARCHITECTURE.md). The LLM-readable inventory lives in [`llms.txt`](llms.txt).
 
 ## Contributing
 

--- a/doc/core-concepts/theming.md
+++ b/doc/core-concepts/theming.md
@@ -9,6 +9,7 @@
 - [Spacing and Sizing](#spacing-and-sizing)
 - [Borders and Shadows](#borders-and-shadows)
 - [Customizing Defaults](#customizing-defaults)
+- [Aliases](#aliases)
 - [Quick Reference](#quick-reference)
 
 <x-preview path="core-concepts/theming_example" size="md" source="example/lib/pages/core-concepts/theming_example.dart"></x-preview>
@@ -197,10 +198,46 @@ final darkTheme = myDefaultTheme.copyWith(
 );
 ```
 
+<a name="aliases"></a>
+## Aliases
+
+`WindThemeData(aliases: {...})` lets you define short, bare-token names that expand to full utility strings before parsing. Every `W` widget resolves aliases centrally, so a class name like `row` becomes `flex flex-row` everywhere without any per-widget wiring.
+
+```dart
+WindThemeData(
+  aliases: {
+    'row':   'flex flex-row',
+    'col':   'flex flex-col',
+    'center': 'items-center justify-center',
+    'row-c': 'row center',      // recursive: expands 'row' and 'center' first
+  },
+)
+```
+
+With this configuration, the following `className` values are equivalent:
+
+```dart
+// Before aliases
+WDiv(className: 'flex flex-row items-center justify-center bg-white dark:bg-gray-800')
+
+// After aliases
+WDiv(className: 'row-c bg-white dark:bg-gray-800')
+```
+
+**How expansion works:**
+
+- Only bare, unprefixed tokens are matched. `md:row` is **not** expanded; only a standalone `row` token qualifies.
+- Expansion is recursive: an alias value may reference other aliases. The expander resolves all aliases before handing the result to the parser.
+- Aliases are empty by default (`{}`). The feature is purely opt-in: a `WindThemeData` without an `aliases` key behaves identically to today.
+- If an alias key shadows a built-in token (for example, `'flex': 'flex flex-row'`), the alias wins and Wind emits a debug-mode warning so you can rename before shipping.
+
+> [!NOTE]
+> Alias keys must be plain strings with no colons or slashes. Prefix variants such as `hover:row` or `md:col` are not expanded.
+
 <a name="quick-reference"></a>
 ## Quick Reference
 
-`WindThemeData` exposes 23 configurable fields. The table below groups them by concern.
+`WindThemeData` exposes 24 configurable fields. The table below groups them by concern.
 
 ### Mode and Behavior
 
@@ -233,6 +270,7 @@ final darkTheme = myDefaultTheme.copyWith(
 | `transitionDurations` | `Map<String, Duration>` | Duration scale (`duration-200`, etc.) |
 | `transitionCurves` | `Map<String, Curve>` | Easing scale (`ease-in-out`, etc.) |
 | `animations` | `Map<String, WindAnimationType>` | Animation types (`animate-spin`, etc.) |
+| `aliases` | `Map<String, String>` | Bare-token shorthands that expand (recursively) before parsing. Default `{}`. See [Aliases](#aliases). |
 
 ### Ring (Focus) Effects
 

--- a/example/lib/pages/core-concepts/theming_example.dart
+++ b/example/lib/pages/core-concepts/theming_example.dart
@@ -13,7 +13,7 @@ class ThemingExamplePage extends StatelessWidget {
     return ExampleScaffold(
       title: 'Theme Configuration',
       description:
-          'WindThemeData drives every utility. Override any of 23 fields; unset ones inherit the Tailwind-equivalent defaults.',
+          'WindThemeData drives every utility. Override any of 24 fields; unset ones inherit the Tailwind-equivalent defaults.',
       gradient: 'from-emerald-500 to-teal-600',
       children: [
         ExampleSection(
@@ -40,6 +40,7 @@ class ThemingExamplePage extends StatelessWidget {
         const _TypographyScaleSection(),
         const _BorderRadiusSection(),
         const _ShadowScaleSection(),
+        const _AliasesSection(),
         ExampleSection(
           title: 'Theme Change Callbacks',
           description:
@@ -301,6 +302,115 @@ class _ShadowScaleSection extends StatelessWidget {
             ],
           );
         }).toList(),
+      ),
+    );
+  }
+}
+
+class _AliasesSection extends StatelessWidget {
+  const _AliasesSection();
+
+  @override
+  Widget build(BuildContext context) {
+    const aliasMap = {
+      'row': 'flex flex-row',
+      'col': 'flex flex-col',
+      'center': 'items-center justify-center',
+    };
+
+    return ExampleSection(
+      title: 'Aliases',
+      description:
+          'Map shorthand tokens to full class strings via WindThemeData(aliases: {...}). '
+          'The alias is expanded recursively before parsing, so "row center gap-2" and '
+          '"flex flex-row items-center justify-center gap-2" produce identical layout.',
+      child: WindTheme(
+        data: WindThemeData(aliases: aliasMap),
+        child: WDiv(
+          className: 'flex flex-col gap-4',
+          children: [
+            WDiv(
+              className: 'flex flex-col gap-2',
+              children: [
+                WText(
+                  'Alias form',
+                  className: 'text-xs font-semibold uppercase tracking-wide '
+                      'text-slate-500 dark:text-slate-400',
+                ),
+                WDiv(
+                  className: 'p-3 rounded-lg bg-slate-100 dark:bg-slate-800',
+                  child: WDiv(
+                    className: 'row center gap-2',
+                    children: [
+                      WDiv(
+                        className: 'w-8 h-8 rounded bg-emerald-500',
+                      ),
+                      WDiv(
+                        className: 'w-8 h-8 rounded bg-teal-500',
+                      ),
+                      WDiv(
+                        className: 'w-8 h-8 rounded bg-cyan-500',
+                      ),
+                      WText(
+                        'row center gap-2',
+                        className:
+                            'text-xs font-mono text-slate-600 dark:text-slate-300',
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            WDiv(
+              className: 'flex flex-col gap-2',
+              children: [
+                WText(
+                  'Expanded form (identical output)',
+                  className: 'text-xs font-semibold uppercase tracking-wide '
+                      'text-slate-500 dark:text-slate-400',
+                ),
+                WDiv(
+                  className: 'p-3 rounded-lg bg-slate-100 dark:bg-slate-800',
+                  child: WDiv(
+                    className:
+                        'flex flex-row items-center justify-center gap-2',
+                    children: [
+                      WDiv(
+                        className: 'w-8 h-8 rounded bg-emerald-500',
+                      ),
+                      WDiv(
+                        className: 'w-8 h-8 rounded bg-teal-500',
+                      ),
+                      WDiv(
+                        className: 'w-8 h-8 rounded bg-cyan-500',
+                      ),
+                      WText(
+                        'flex flex-row items-center justify-center gap-2',
+                        className:
+                            'text-xs font-mono text-slate-600 dark:text-slate-300',
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            _CodeBlock(
+              code: 'WindTheme(\n'
+                  '  data: WindThemeData(\n'
+                  '    aliases: {\n'
+                  "      'row': 'flex flex-row',\n"
+                  "      'col': 'flex flex-col',\n"
+                  "      'center': 'items-center justify-center',\n"
+                  '    },\n'
+                  '  ),\n'
+                  '  child: WDiv(\n'
+                  "    className: 'row center gap-2',\n"
+                  '    children: [...],\n'
+                  '  ),\n'
+                  ')',
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/parser/alias_expander.dart
+++ b/lib/src/parser/alias_expander.dart
@@ -1,0 +1,112 @@
+/// Maximum expansion depth before resolution stops.
+///
+/// Eight levels cover any realistic alias chain (an alias whose value is an
+/// alias whose value is an alias, etc.); a deeper chain almost certainly means
+/// a misconfiguration, so the cap is a backstop alongside the per-chain cycle
+/// guard rather than the primary termination mechanism.
+const int _maxExpansionDepth = 8;
+
+/// Expands user-defined className aliases into their underlying tokens.
+///
+/// This is a PURE function: a className string plus an alias map go in, an
+/// expanded className string comes out. It imports no parser, theme, or Flutter
+/// symbols so it can be unit-tested in isolation.
+///
+/// ### Behavior
+///
+/// - When [aliases] is empty, the input is returned unchanged (zero-cost fast
+///   path; the hot rendering path pays nothing when no aliases are configured).
+/// - Otherwise the className is split on whitespace and each token is expanded
+///   independently. Only a WHOLE unprefixed token equal to an alias key is
+///   replaced (`row` matches the key `row`; `md:row` does not). The replacement
+///   is the alias value's own tokens, which may themselves contain prefixes or
+///   further aliases and are expanded recursively.
+/// - Token order and duplicates are preserved (no dedup); the parser is
+///   last-class-wins, so dropping a trailing duplicate would change semantics.
+///   Two independent occurrences of the same alias both expand.
+///
+/// ### Termination
+///
+/// Each token expands down its own chain, guarded by a per-chain visited-set:
+/// re-encountering a key already on the current chain (a self-cycle `a -> a` or
+/// a mutual cycle `a -> b -> a`) leaves the token unexpanded instead of
+/// looping. [_maxExpansionDepth] is a secondary backstop. On a cycle or cap hit
+/// the offending token is kept verbatim and [onWarn] (when provided) is invoked
+/// with a diagnostic message; the function never throws.
+///
+/// ### Example
+///
+/// ```dart
+/// expandAliases('row-c', {'row': 'flex flex-row', 'row-c': 'row items-center'});
+/// // -> 'flex flex-row items-center'
+/// ```
+String expandAliases(
+  String className,
+  Map<String, String> aliases, {
+  void Function(String message)? onWarn,
+}) {
+  // Fast path: no aliases configured, nothing to expand.
+  if (aliases.isEmpty) {
+    return className;
+  }
+
+  final expanded = <String>[];
+
+  for (final token in _tokenize(className)) {
+    _expandToken(token, aliases, <String>{}, 0, expanded, onWarn);
+  }
+
+  return expanded.join(' ');
+}
+
+/// Splits a className string on whitespace, dropping empty fragments.
+///
+/// Mirrors WindParser.findAndGroupClasses so multiline / multi-space input
+/// tokenizes identically on both sides.
+Iterable<String> _tokenize(String value) =>
+    value.split(RegExp(r'\s+')).where((s) => s.isNotEmpty);
+
+/// Expands a single [token], appending the resulting tokens to [out].
+///
+/// [chain] is the set of alias keys already expanded on the current resolution
+/// path; a token present in it (cycle) or a [depth] past [_maxExpansionDepth]
+/// (cap) is appended unexpanded after warning. A fresh chain copy is passed
+/// down each branch so sibling occurrences of the same alias both expand.
+void _expandToken(
+  String token,
+  Map<String, String> aliases,
+  Set<String> chain,
+  int depth,
+  List<String> out,
+  void Function(String message)? onWarn,
+) {
+  final replacement = aliases[token];
+
+  // Not an alias key (unknown token, or any prefixed token): keep verbatim.
+  if (replacement == null) {
+    out.add(token);
+    return;
+  }
+
+  // Cycle guard: this key is already on the current resolution chain.
+  if (chain.contains(token)) {
+    onWarn?.call("Wind alias '$token' forms a cycle; left unexpanded.");
+    out.add(token);
+    return;
+  }
+
+  // Cap guard: chain deeper than the backstop allows.
+  if (depth >= _maxExpansionDepth) {
+    onWarn?.call(
+      "Wind alias '$token' exceeds the $_maxExpansionDepth-level "
+      'expansion cap; left unexpanded.',
+    );
+    out.add(token);
+    return;
+  }
+
+  final nextChain = {...chain, token};
+  for (final inner in _tokenize(replacement)) {
+    _expandToken(inner, aliases, nextChain, depth + 1, out, onWarn);
+  }
+}

--- a/lib/src/parser/alias_expander.dart
+++ b/lib/src/parser/alias_expander.dart
@@ -80,9 +80,18 @@ void _expandToken(
   List<String> out,
   void Function(String message)? onWarn,
 ) {
+  // Bare-token contract: a prefixed token (anything carrying a ':' variant,
+  // such as md:row or dark:bg-gray-900) is never alias-expanded, even if the
+  // map happens to hold a matching prefixed key. Only whole unprefixed tokens
+  // are eligible, so the lookup is skipped before it can match.
+  if (token.contains(':')) {
+    out.add(token);
+    return;
+  }
+
   final replacement = aliases[token];
 
-  // Not an alias key (unknown token, or any prefixed token): keep verbatim.
+  // Not an alias key (unknown bare token): keep verbatim.
   if (replacement == null) {
     out.add(token);
     return;

--- a/lib/src/parser/wind_parser.dart
+++ b/lib/src/parser/wind_parser.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'parsers/background_parser.dart';
@@ -20,6 +21,7 @@ import 'parsers/transition_parser.dart';
 import 'parsers/ring_parser.dart';
 import 'parsers/svg_parser.dart';
 import 'parsers/animation_parser.dart';
+import 'alias_expander.dart';
 import 'wind_context.dart';
 import 'wind_style.dart';
 
@@ -78,6 +80,12 @@ class WindParser {
   /// Cache for parsed styles
   static final Map<String, WindStyle> _styleCache = {};
 
+  /// Alias keys already warned about this session (debug-only).
+  ///
+  /// Both shadow warnings and cycle/cap warnings dedup through this set so a
+  /// repeated render of the same offending className logs once, not per frame.
+  static final Set<String> _warnedAliases = {};
+
   /// Map of property names to their respective parsers
   static final Map<String, WindParserInterface> _parserMap = {
     'background': const BackgroundParser(),
@@ -108,6 +116,7 @@ class WindParser {
   /// invalidated per unique context, so manual clearing is rarely needed.
   static void clearCache() {
     _styleCache.clear();
+    _warnedAliases.clear();
   }
 
   /// Number of entries currently held in the style cache.
@@ -147,7 +156,26 @@ class WindParser {
     Set<String>? states,
   }) {
     final windContext = WindContext.build(context, states: states);
-    final cacheKey = windContext.cacheKey(className);
+
+    // Expand user-defined aliases BEFORE the cache key is computed so the key
+    // reflects the resolved tokens: two themes whose alias maps differ for the
+    // same raw className produce distinct keys, and every W-widget plus
+    // WDynamic shares this central expansion. The expander returns the input
+    // unchanged when no aliases are configured, so the hot path is untouched.
+    final aliases = windContext.theme.aliases;
+    final expanded = expandAliases(
+      className,
+      aliases,
+      // The pure expander stays Flutter-free; the kDebugMode gate and the
+      // warn-once dedup live here, in the caller.
+      onWarn: kDebugMode ? (message) => _warnAlias(className, message) : null,
+    );
+
+    if (kDebugMode) {
+      _warnOnShadowedAliases(aliases);
+    }
+
+    final cacheKey = windContext.cacheKey(expanded);
 
     // Cache key is composed from windContext + className only; it does NOT
     // include baseStyle. Reading from or writing into the cache when a caller
@@ -159,7 +187,39 @@ class WindParser {
       return _styleCache[cacheKey]!;
     }
 
-    return _parseAndCache(className, windContext, cacheKey, baseStyle);
+    return _parseAndCache(expanded, windContext, cacheKey, baseStyle);
+  }
+
+  /// Emits a debug-only cycle/cap warning, deduped per session.
+  ///
+  /// Keyed by the offending [className] so a repeated render of the same input
+  /// logs once. The diagnostic [message] comes from the alias expander.
+  static void _warnAlias(String className, String message) {
+    if (_warnedAliases.add('cycle:$className')) {
+      debugPrint(message);
+    }
+  }
+
+  /// Emits a debug-only warning for any alias key that shadows a built-in
+  /// token, deduped per session.
+  ///
+  /// An alias whose key a real parser would `canParse` makes that built-in
+  /// token unreachable, so the developer is told once. This walks the alias map
+  /// against every parser and is gated behind `kDebugMode` at the call site, so
+  /// release builds never run it.
+  static void _warnOnShadowedAliases(Map<String, String> aliases) {
+    for (final key in aliases.keys) {
+      if (!_warnedAliases.add('shadow:$key')) continue;
+
+      final shadowsBuiltIn =
+          _parserMap.values.any((parser) => parser.canParse(key));
+      if (shadowsBuiltIn) {
+        debugPrint(
+          "Wind alias '$key' shadows a built-in token; "
+          'the built-in is now unreachable.',
+        );
+      }
+    }
   }
 
   /// Internal method to parse and cache the style.

--- a/lib/src/theme/wind_theme_data.dart
+++ b/lib/src/theme/wind_theme_data.dart
@@ -161,6 +161,9 @@ class WindThemeData {
   /// A map of animation class names to animation types.
   final Map<String, WindAnimationType> animations;
 
+  /// User-defined className shortcut aliases; expanded before parsing. See WindParser alias expansion.
+  final Map<String, String> aliases;
+
   /// Creates a new [WindThemeData] instance.
   ///
   /// If [colors] or [screens] are not provided, they will default
@@ -189,6 +192,7 @@ class WindThemeData {
     Map<String, Duration>? transitionDurations,
     Map<String, Curve>? transitionCurves,
     Map<String, WindAnimationType>? animations,
+    Map<String, String>? aliases,
   })  : colors = (Map<String, MaterialColor>.from(_initColors())
           ..addAll(colors ?? {})),
         fontSizes = (Map<String, double>.from(default_font_sizes.fontSizes)
@@ -233,7 +237,8 @@ class WindThemeData {
         )..addAll(transitionCurves ?? {})),
         animations = (Map<String, WindAnimationType>.from(
           default_animations.animations,
-        )..addAll(animations ?? {}));
+        )..addAll(animations ?? {})),
+        aliases = Map<String, String>.from(aliases ?? const {});
 
   /// Initializes the default colors from the predefined color map.
   ///
@@ -342,6 +347,7 @@ class WindThemeData {
     Map<String, Duration>? transitionDurations,
     Map<String, Curve>? transitionCurves,
     Map<String, WindAnimationType>? animations,
+    Map<String, String>? aliases,
   }) {
     return WindThemeData(
       brightness: brightness ?? this.brightness,
@@ -404,6 +410,9 @@ class WindThemeData {
       animations: animations != null
           ? (Map.from(this.animations)..addAll(animations))
           : this.animations,
+      aliases: aliases != null
+          ? (Map.from(this.aliases)..addAll(aliases))
+          : this.aliases,
     );
   }
 
@@ -508,7 +517,8 @@ class WindThemeData {
         mapEquals(other.shadows, shadows) &&
         mapEquals(other.transitionDurations, transitionDurations) &&
         mapEquals(other.transitionCurves, transitionCurves) &&
-        mapEquals(other.animations, animations);
+        mapEquals(other.animations, animations) &&
+        mapEquals(other.aliases, aliases);
   }
 
   // hashCode is composed from the scalar fields only. The map fields are

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 23-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 22 W-prefix widgets, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.0.0 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 22 W-prefix widgets, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.0.0 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 
@@ -78,7 +78,7 @@ if (kDebugMode) Wind.installDebugResolver();
 
 - [Installation](https://fluttersdk.com/wind/getting-started/installation.md): pubspec add + WindTheme wrap + first className.
 - [Utility-first](https://fluttersdk.com/wind/core-concepts/utility-first.md): why className beats nested widgets.
-- [Theming](https://fluttersdk.com/wind/core-concepts/theming.md): 23 `WindThemeData` fields, override patterns.
+- [Theming](https://fluttersdk.com/wind/core-concepts/theming.md): 24 `WindThemeData` fields, override patterns.
 - [Theme binding](https://fluttersdk.com/wind/core-concepts/theme-binding.md): `WindTheme` placement, `OverlayEntry` caveat.
 - [Dark mode](https://fluttersdk.com/wind/core-concepts/dark-mode.md): `dark:` prefix, runtime toggle, system sync.
 - [Responsive design](https://fluttersdk.com/wind/core-concepts/responsive-design.md): breakpoint prefixes + `WBreakpoint` escape hatch.

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -3,10 +3,10 @@ name: wind-ui
 description: "fluttersdk_wind 1.0: utility-first Flutter styling with Tailwind-syntax className strings. 22 public widgets (WDiv, WText, WButton, WInput, WSelect, WCheckbox, WDatePicker, WPopover, WAnchor, WIcon, WImage, WSvg, WSpacer, WBreakpoint, WDynamic, WKeyboardActions, WindAnimationWrapper + 5 WForm* wrappers) consume className through a 19-parser pipeline (19 implementation files organized into 12 token families for teaching) that emits a cached immutable WindStyle. Prefixes stack freely (dark: / hover: / focus: / md: / lg: / ios: / android: / web: / mobile: / selected: / loading: / disabled: / error: / checked: / custom). Last class wins; unknown tokens fail silently. Every color token (bg-, text-, border-, ring-, shadow-, fill-) needs a dark: pair in the same className. TRIGGER when: writing or editing any UI in a Flutter app that depends on `fluttersdk_wind`; any className string; any W-prefix widget; any WindTheme / WindThemeData reference; the user mentions Tailwind for Flutter, utility-first, className, or wind-ui. DO NOT TRIGGER when: backend / API / state-management work that does not touch a widget tree; Flutter projects that do not have fluttersdk_wind in pubspec.yaml; Material-only widgets (Scaffold, AppBar, Dialog) without Wind content inside them."
 when_to_use: |
   Any task that produces, modifies, or audits Wind-styled Flutter UI: composing a className string, picking the right W-widget for a use case, integrating with a Form / FormField, customizing WindThemeData, wiring dark-mode pairs, debugging an unexpected layout, recovering from RenderFlex overflow, building a popover or dropdown, rendering a JSON tree via WDynamic, wiring Wind.installDebugResolver for kDebugMode tooling, or migrating a Tailwind className from web. Apply BEFORE writing the first line of UI in a Wind-using file, not as an audit pass.
-version: 2.3.0
+version: 2.4.0
 ---
 
-<!-- fluttersdk_wind 1.0.x | Skill v2.3.0 (2026-06-16) -->
+<!-- fluttersdk_wind 1.0.x | Skill v2.4.0 (2026-06-17) -->
 
 # Wind UI 1.0
 
@@ -394,7 +394,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return WindTheme(
-      data: WindThemeData(/* 23 optional fields; defaults applied otherwise */),
+      data: WindThemeData(/* 24 optional fields; defaults applied otherwise */),
       builder: (context, controller) => MaterialApp(
         theme: controller.toThemeData(),
         home: const Scaffold(body: HomePage()),
@@ -405,6 +405,8 @@ class MyApp extends StatelessWidget {
 ```
 
 Brightness syncs with the OS by default. Toggle manually via `context.windTheme.toggleTheme()` (disables auto-sync). Reset to OS via `context.windTheme.resetToSystem()`. Read brightness from `context.windIsDark`. Full theme customization (custom color palettes, custom breakpoints, custom font families, `baseSpacingUnit` for non-4 px spacing scale): `${CLAUDE_SKILL_DIR}/references/theme.md`.
+
+`WindThemeData.aliases` (`Map<String, String>`, empty by default) maps bare-token shorthand keys to full className strings (for example `{'btn-primary': 'bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-lg'}`). Keys must be bare tokens (no prefix, no colon). Expansion is recursive (an alias may expand to another alias), alias wins over a real token of the same name (debug warning on shadow), and expansion happens centrally in `WindParser.parse` before any parser runs, so aliases work in every widget and in `WDynamic` without additional wiring.
 
 `Wind.installDebugResolver()` is one-time setup inside `kDebugMode`. Idempotent; tree-shaken in release. Do NOT add it on every UI change — it belongs in `main.dart` only.
 

--- a/skills/wind-ui/references/tailwind-divergence.md
+++ b/skills/wind-ui/references/tailwind-divergence.md
@@ -178,6 +178,9 @@ Wind adds a small set of tokens for Flutter-specific scenarios.
 ### SVG fill preservation
 - `preserve-colors` — disables Wind's color filter; renders embedded SVG colors unchanged (QR codes, logos, multi-color illustrations)
 
+### className aliases (runtime shorthand expansion)
+- `WindThemeData.aliases` (`Map<String, String>`) maps bare-token keys to className strings, expanded recursively by `WindParser.parse` before any parser runs. Closest Tailwind analogue: `@layer components` / UnoCSS shortcuts; unlike those, there is no CSS cascade and expansion is a pure string substitution at runtime. Keys are bare tokens only (no prefix, no colon). An alias that shadows a real token wins and emits a debug warning. Empty by default; works in every widget and in `WDynamic` without additional wiring.
+
 ### Debug instrumentation
 - `debug` token — triggers `WindLogger` to log composition tree + final styles
 - `Wind.installDebugResolver()` (Dart API) — exposes 7 fields per widget to external tooling

--- a/skills/wind-ui/references/theme.md
+++ b/skills/wind-ui/references/theme.md
@@ -62,7 +62,7 @@ Defaults applied automatically: 22 color families, 5 responsive breakpoints (640
 
 ## 2. WindThemeData fields
 
-23 fields; pass only what you want to override. All are nullable except `brightness`, which defaults to `Brightness.light` rather than null, so they are not literally all nullable.
+24 fields; pass only what you want to override. All are nullable except `brightness`, which defaults to `Brightness.light` rather than null, so they are not literally all nullable.
 
 ```dart
 WindThemeData({
@@ -89,6 +89,7 @@ WindThemeData({
   Map<String, Duration>? transitionDurations,      // duration-* key → Duration
   Map<String, Curve>? transitionCurves,            // ease-* key → Curve
   Map<String, WindAnimationType>? animations,      // animate-* key → enum value
+  Map<String, String>? aliases,                    // bare-token shorthand → className string, expanded before parsing
 })
 ```
 

--- a/skills/wind-ui/references/tokens.md
+++ b/skills/wind-ui/references/tokens.md
@@ -47,6 +47,8 @@ Inline color escape hatches that bypass the cache key:
 - `WText(foregroundColor: Color)` overrides any `text-*` / `dark:text-*`.
 - `WIcon(foregroundColor: Color)` overrides any `text-*` / `dark:text-*`.
 
+`WindThemeData.aliases` shorthand expansion: if the active theme has `aliases` set, `WindParser.parse` expands matching bare tokens to their full className strings before the 19-parser pipeline runs. Aliases are not tokens themselves and do not appear in the catalog below; they are transparent to every parser. See `references/theme.md` and `references/tailwind-divergence.md` for details.
+
 ---
 
 ## 2. Layout (flexbox + grid + display)

--- a/test/parser/alias_expander_test.dart
+++ b/test/parser/alias_expander_test.dart
@@ -85,5 +85,37 @@ void main() {
 
       expect(warnings, isNotEmpty);
     });
+
+    test('stops at the depth cap on an acyclic chain longer than the cap', () {
+      // A non-cyclic chain (every link is a distinct key, so the per-chain
+      // visited-set never trips) longer than the cap exercises the depth
+      // backstop: resolution stops, leaves the deep token unexpanded, and warns.
+      // The chain length (12) must stay greater than _maxExpansionDepth (8) for
+      // this test to keep hitting the cap branch; widen it if the cap is raised.
+      const chain = {
+        'a1': 'a2',
+        'a2': 'a3',
+        'a3': 'a4',
+        'a4': 'a5',
+        'a5': 'a6',
+        'a6': 'a7',
+        'a7': 'a8',
+        'a8': 'a9',
+        'a9': 'a10',
+        'a10': 'a11',
+        'a11': 'a12',
+        'a12': 'leaf',
+      };
+      final warnings = <String>[];
+
+      final result = expandAliases('a1', chain, onWarn: warnings.add);
+
+      // The cap trips before the chain resolves to its 'leaf' tail; the
+      // offending token is kept verbatim rather than expanded further.
+      expect(result, isNot(contains('leaf')));
+      expect(result.split(' '), hasLength(1));
+      expect(warnings, isNotEmpty);
+      expect(warnings.any((w) => w.contains('expansion cap')), isTrue);
+    });
   });
 }

--- a/test/parser/alias_expander_test.dart
+++ b/test/parser/alias_expander_test.dart
@@ -24,7 +24,7 @@ void main() {
         },
       );
 
-      expect(result, contains('flex flex-row items-center'));
+      expect(result, 'flex flex-row items-center');
     });
 
     test('terminates on a self-cycle without hanging', () {
@@ -34,10 +34,9 @@ void main() {
     });
 
     test('terminates on a mutual cycle without hanging', () {
-      // a -> b -> a forms a loop; resolution stops at the repeated token.
-      final result = expandAliases('a', const {'a': 'b', 'b': 'a'});
-
-      expect(result.split(' '), isNotEmpty);
+      // a -> b -> a forms a loop; 'a' expands to 'b', 'b' expands back to 'a'
+      // which is already on the chain, so the repeated 'a' is left verbatim.
+      expect(expandAliases('a', const {'a': 'b', 'b': 'a'}), 'a');
     });
 
     test('passes an unknown token through unchanged', () {
@@ -49,6 +48,15 @@ void main() {
       // equal to the key `row`, so it passes through verbatim.
       expect(
         expandAliases('md:row', const {'row': 'flex flex-row'}),
+        'md:row',
+      );
+    });
+
+    test('never expands a prefixed token even when a prefixed key exists', () {
+      // A prefixed token is ineligible regardless of the map: a `md:row` key is
+      // not bare, so the bare-token contract leaves the token unexpanded.
+      expect(
+        expandAliases('md:row', const {'md:row': 'flex flex-row'}),
         'md:row',
       );
     });
@@ -83,7 +91,8 @@ void main() {
         onWarn: warnings.add,
       );
 
-      expect(warnings, isNotEmpty);
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('cycle'));
     });
 
     test('stops at the depth cap on an acyclic chain longer than the cap', () {

--- a/test/parser/alias_expander_test.dart
+++ b/test/parser/alias_expander_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttersdk_wind/src/parser/alias_expander.dart';
+
+void main() {
+  group('expandAliases', () {
+    test('returns the input unchanged when the alias map is empty', () {
+      expect(expandAliases('flex p-4', const {}), 'flex p-4');
+    });
+
+    test('expands a single alias into its tokens', () {
+      expect(
+        expandAliases('row', const {'row': 'flex flex-row'}),
+        'flex flex-row',
+      );
+    });
+
+    test('expands recursively when an alias value references another alias',
+        () {
+      final result = expandAliases(
+        'row-c',
+        const {
+          'row': 'flex flex-row',
+          'row-c': 'row items-center',
+        },
+      );
+
+      expect(result, contains('flex flex-row items-center'));
+    });
+
+    test('terminates on a self-cycle without hanging', () {
+      // A self-referential alias must not loop; the offending token is left
+      // unexpanded once it is detected as already visited.
+      expect(expandAliases('a', const {'a': 'a'}), 'a');
+    });
+
+    test('terminates on a mutual cycle without hanging', () {
+      // a -> b -> a forms a loop; resolution stops at the repeated token.
+      final result = expandAliases('a', const {'a': 'b', 'b': 'a'});
+
+      expect(result.split(' '), isNotEmpty);
+    });
+
+    test('passes an unknown token through unchanged', () {
+      expect(expandAliases('foo', const {'row': 'flex flex-row'}), 'foo');
+    });
+
+    test('does not match a prefixed token against a bare alias key', () {
+      // Only an unprefixed whole token may match an alias key; `md:row` is not
+      // equal to the key `row`, so it passes through verbatim.
+      expect(
+        expandAliases('md:row', const {'row': 'flex flex-row'}),
+        'md:row',
+      );
+    });
+
+    test('passes a prefixed token inside an alias value through as-is', () {
+      expect(
+        expandAliases('card', const {'card': 'dark:bg-gray-900'}),
+        'dark:bg-gray-900',
+      );
+    });
+
+    test('preserves duplicate tokens and their order (no dedup)', () {
+      expect(
+        expandAliases('p-2 p-4 p-2', const {}),
+        'p-2 p-4 p-2',
+      );
+    });
+
+    test('preserves order when expanding alongside non-alias tokens', () {
+      expect(
+        expandAliases('p-4 row m-2', const {'row': 'flex flex-row'}),
+        'p-4 flex flex-row m-2',
+      );
+    });
+
+    test('invokes onWarn when a cycle is detected', () {
+      final warnings = <String>[];
+
+      expandAliases(
+        'a',
+        const {'a': 'a'},
+        onWarn: warnings.add,
+      );
+
+      expect(warnings, isNotEmpty);
+    });
+  });
+}

--- a/test/parser/wind_parser_alias_test.dart
+++ b/test/parser/wind_parser_alias_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluttersdk_wind/src/parser/wind_parser.dart';
+import 'package:fluttersdk_wind/src/parser/wind_style.dart';
+import 'package:fluttersdk_wind/src/theme/wind_theme.dart';
+import 'package:fluttersdk_wind/src/theme/wind_theme_data.dart';
+import 'package:fluttersdk_wind/src/widgets/w_div.dart';
+
+/// Wraps [child] in a [WindTheme] carrying the supplied [aliases] so
+/// `WindParser.parse` resolves them through the real `parse()` path.
+Widget wrapWithAliases(Map<String, String> aliases, Widget child) {
+  return MaterialApp(
+    home: WindTheme(
+      data: WindThemeData(
+        screens: const {'sm': 640, 'md': 768, 'lg': 1024, 'xl': 1280},
+        aliases: aliases,
+      ),
+      child: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    WindParser.clearCache();
+  });
+
+  group('WindParser alias expansion', () {
+    testWidgets('expands an alias before parsing so it yields a flex/row style',
+        (tester) async {
+      late WindStyle style;
+
+      await tester.pumpWidget(
+        wrapWithAliases(
+          const {'row': 'flex flex-row'},
+          Builder(
+            builder: (context) {
+              style = WindParser.parse('row', context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(style.displayType, WindDisplayType.flex);
+      expect(style.flexDirection, Axis.horizontal);
+    });
+
+    testWidgets('expands recursively before parsing', (tester) async {
+      late WindStyle style;
+
+      await tester.pumpWidget(
+        wrapWithAliases(
+          const {
+            'row': 'flex flex-row',
+            'row-c': 'row items-center',
+          },
+          Builder(
+            builder: (context) {
+              style = WindParser.parse('row-c', context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(style.displayType, WindDisplayType.flex);
+      expect(style.flexDirection, Axis.horizontal);
+      expect(style.crossAxisAlignment, CrossAxisAlignment.center);
+    });
+
+    testWidgets(
+        'two themes with different alias maps keep distinct cache entries',
+        (tester) async {
+      late WindStyle rowStyle;
+
+      await tester.pumpWidget(
+        wrapWithAliases(
+          const {'box': 'flex flex-row'},
+          Builder(
+            builder: (context) {
+              rowStyle = WindParser.parse('box', context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(rowStyle.flexDirection, Axis.horizontal);
+      final sizeAfterRow = WindParser.cacheSize;
+
+      late WindStyle colStyle;
+
+      await tester.pumpWidget(
+        wrapWithAliases(
+          const {'box': 'flex flex-col'},
+          Builder(
+            builder: (context) {
+              colStyle = WindParser.parse('box', context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // Same raw className `box`, different alias values: the cache key is
+      // computed from the expanded string, so the two produce distinct entries
+      // and distinct results rather than a stale cache hit.
+      expect(colStyle.flexDirection, Axis.vertical);
+      expect(WindParser.cacheSize, greaterThan(sizeAfterRow));
+    });
+
+    testWidgets('a WDiv with className:row renders a horizontal Flex',
+        (tester) async {
+      // The central-injection smoke: a real widget, not just a parse() call,
+      // proves the alias resolves through the rendering path.
+      await tester.pumpWidget(
+        wrapWithAliases(
+          const {'row': 'flex flex-row'},
+          const WDiv(
+            className: 'row',
+            children: [Text('a'), Text('b')],
+          ),
+        ),
+      );
+
+      // A horizontal flex renders as a concrete Row (find.byType matches the
+      // exact runtime type, not the Flex superclass).
+      expect(find.byType(Row), findsOneWidget);
+      expect(find.byType(Column), findsNothing);
+    });
+  });
+
+  group('WindParser alias debug diagnostics', () {
+    // These diagnostics are kDebugMode-gated; flutter test runs in debug mode,
+    // so the branches execute. We capture debugPrint to assert they fire.
+    testWidgets('warns once when an alias key shadows a built-in token',
+        (tester) async {
+      final logs = <String>[];
+      final original = debugPrint;
+      debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+
+      try {
+        await tester.pumpWidget(
+          wrapWithAliases(
+            const {'flex': 'flex-row'},
+            Builder(
+              builder: (context) {
+                WindParser.parse('flex', context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      } finally {
+        debugPrint = original;
+      }
+
+      expect(
+        logs.where((l) => l.contains("alias 'flex' shadows a built-in")).length,
+        1,
+      );
+    });
+
+    testWidgets('warns when a cyclic alias is expanded through parse',
+        (tester) async {
+      final logs = <String>[];
+      final original = debugPrint;
+      debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+
+      try {
+        await tester.pumpWidget(
+          wrapWithAliases(
+            const {'a': 'a'},
+            Builder(
+              builder: (context) {
+                WindParser.parse('a', context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      } finally {
+        debugPrint = original;
+      }
+
+      expect(logs.any((l) => l.contains("alias 'a' forms a cycle")), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #104.

## What

Adds `WindThemeData.aliases`, a map of bare-token shorthand keys to full className strings, expanded recursively before parsing:

```dart
WindThemeData(
  aliases: {
    'row': 'flex flex-row',
    'col': 'flex flex-col',
    'center': 'items-center justify-center',
    'row-c': 'row items-center justify-center', // recursive
  },
)

// then anywhere:
WDiv(className: 'row-c gap-2', children: [...])
```

## Design decisions (differ from the issue's proposal, on purpose)

- **Central injection, not `WDiv.build()`**: expansion runs once in `WindParser.parse()`, BEFORE the cache key is computed. Every W-widget and `WDynamic` benefit, not just `WDiv`, and the cache stays correct. The issue proposed preprocessing in `WDiv.build()`; doing it centrally is what closes the #101 class of silent unknown-token failures everywhere (`WDiv(className: 'row')` now renders a Row, not the Column fallback).
- **Expanded string is the cache key**: two themes with different alias maps for the same raw className get distinct cache entries (no collision).
- **Bare-token-only keys**: `row` expands; `md:row` does not (it stays a single token and silently no-ops, consistent with Wind's unknown-token contract). Alias VALUES may contain prefixed tokens (`'card': 'dark:bg-gray-900 ...'`).
- **Termination without throwing**: a per-resolution visited-set cycle guard plus a depth cap; on a cycle or cap hit the offending token is left unexpanded (Wind's silent-ignore contract). Self-cycles and mutual cycles terminate immediately.
- **Order- and duplicate-preserving**: no dedup (the parser is last-class-wins).
- **Empty by default**: pure opt-in; themes that do not set `aliases` are byte-identical on the hot path (empty-map fast path).
- **Debug-only diagnostics** (`kDebugMode`, warn-once): a warning when an alias key shadows a built-in token, and when a cycle or cap is hit. Zero cost in release.

## Tests

11 pure-function unit tests + 6 parser/widget-level tests: basic and recursive expansion, self-cycle and mutual-cycle termination, the depth-cap branch, unknown-token passthrough, bare-key `md:row` no-op, prefixed alias value, per-theme distinct cache entries, `WDiv(className: 'row')` rendering a Row, and the debug shadow/cycle warnings.

## Definition of done

- `dart format --set-exit-if-changed .`: clean
- `dart analyze`: no issues
- `flutter test`: 1427 pass, 1 pre-existing skip
- `./tool/coverage.sh 90`: 91.2%
- `cd example && flutter build web`: succeeds

Five-surface sync done (doc, example, skill, CHANGELOG, README) plus the repo-wide `23 -> 24` theme-field count cascade. SKILL bumped to v2.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aliases` feature to theme configuration for defining custom className shortcuts that recursively expand before parsing.

* **Documentation**
  * Updated theme documentation to reflect increase from 23 to 24 configurable fields.
  * Added comprehensive aliases guide with practical examples and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->