### PR TITLE
fix: restore WInput disabled isEnabled semantics for assistive tech (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 - `WFormInput`, `WFormSelect`, `WFormCheckbox`, and `WFormDatePicker`: the default label, hint, and error class names now carry `dark:` pairs (`text-gray-700 dark:text-gray-300`, `text-gray-500 dark:text-gray-400`, `text-red-500 dark:text-red-400`), so labels and hints stay legible in dark mode instead of rendering dark-on-dark.
 - `WInput`: a conditional `prefix`/`suffix` (for example a clear button that appears once the field has text) no longer drops focus on the first keystroke, and an appearing suffix no longer grows the field height; the placeholder also shares the input strut so the box height stays constant between empty and filled.
 - `WInput`: `enabled: false` is now fully non-interactive again, the field cannot be tapped, focused, or expose selection handles/toolbar (the Material-free backend would otherwise still react to taps on the text).
+- `WInput`: a disabled field again reports `isEnabled: false` to assistive technology through its `Semantics` node. The Material-free rewrite had dropped the flag (the `EditableText` node carries only `isReadOnly`), so a screen reader could not tell a disabled field from a read-only one; the 1.0.0 Material `TextField` exposed it and parity is restored.
 
 ---
 

--- a/lib/src/widgets/w_input.dart
+++ b/lib/src/widgets/w_input.dart
@@ -36,6 +36,15 @@ enum InputType {
 /// shadcn, a custom root, or a bare `WidgetsApp`) without requiring a Material
 /// ancestor.
 ///
+/// ### Ancestor requirements:
+/// - Interactive text selection (the long-press toolbar and drag handles)
+///   needs an [Overlay] ancestor. `MaterialApp`, `CupertinoApp`, and
+///   `WidgetsApp` all provide one; under a custom root with no `Overlay`,
+///   typing, cursor movement, and focus still work, but selection UI is
+///   suppressed rather than throwing.
+/// - A tap anywhere in the input box (not only on the text glyphs) focuses the
+///   field and fires [onTap], restoring `TextField`'s whole-box tap target.
+///
 /// ### Supported Features:
 /// - **Controlled Value:** Pass `value` and `onChanged` for React-style binding
 /// - **Styling:** `bg-gray-50` `text-gray-900` `rounded-lg` `border-gray-300`
@@ -602,7 +611,14 @@ class _WInputState extends State<WInput> {
     // explicitChildNodes: false), producing exactly ONE textField node carrying
     // the label, instead of the second node the old container+MergeSemantics
     // wrapper minted. EditableText already reports value + obscured.
+    //
+    // `enabled` surfaces the disabled state to assistive tech: a disabled field
+    // reports isEnabled: false. EditableText's own node only carries isReadOnly
+    // (a disabled field is read-only), so without this a screen reader could
+    // not distinguish "disabled" from "read-only". The Material TextField in
+    // 1.0.0 exposed this flag; the Material-free rewrite must keep parity.
     result = Semantics(
+      enabled: widget.enabled,
       label: widget.semanticLabel ?? widget.placeholder,
       child: result,
     );

--- a/test/widgets/w_input_test.dart
+++ b/test/widgets/w_input_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Tristate;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
@@ -955,11 +957,11 @@ void main() {
     // `getByLabel(/email/i)` and `getByLabel(/password/i)` resolve via the
     // Flutter web accessibility tree.
     //
-    // NOTE: EditableText does not set `isEnabled` semantics (unlike Material
-    // TextField). `isEnabled` is always `Tristate.none`. Disabled state is
-    // signaled through `isReadOnly: true` (disabled routes to readOnly=true
-    // inside EditableText). The `isTextField` and `isObscured` contracts are
-    // unaffected.
+    // NOTE: the outer `Semantics(enabled: widget.enabled)` surfaces the
+    // enabled state (matching the 1.0.0 Material TextField), so a disabled
+    // field reports `isEnabled: false`. EditableText additionally routes a
+    // disabled field to `readOnly=true`, so `isReadOnly: true` holds as well.
+    // The `isTextField` and `isObscured` contracts are unaffected.
     //
     // The placeholder Text is wrapped in `ExcludeSemantics`, so the single outer
     // `Semantics(label:)` node owns the accessible name exactly (no `'<label>\n
@@ -1002,11 +1004,27 @@ void main() {
           ),
         );
 
-        // EditableText routes disabled=false to readOnly=true. The semantics
-        // node reflects this as isReadOnly rather than isEnabled=false.
+        // The outer Semantics(enabled:) surfaces isEnabled: false for assistive
+        // tech (1.0.0 parity). EditableText also routes disabled to readOnly,
+        // so isReadOnly holds too. Both cues are present.
         final SemanticsNode node = tester.getSemantics(find.byType(WInput));
         expect(node.flagsCollection.isTextField, isTrue);
+        // isEnabled is a Tristate: isFalse means "explicitly disabled" (not the
+        // unset `none` the field would report without the Semantics(enabled:)).
+        expect(node.flagsCollection.isEnabled, Tristate.isFalse);
         expect(node.flagsCollection.isReadOnly, isTrue);
+      });
+
+      testWidgets('reports enabled state when enabled is true', (tester) async {
+        await tester.pumpWidget(
+          wrapWithTheme(const WInput(placeholder: 'Active', value: '')),
+        );
+
+        // An enabled field reports Tristate.isTrue, so the disabled cue above is
+        // a real distinction, not a constant: were the enabled flag unwired,
+        // this would read Tristate.none and fail.
+        final SemanticsNode node = tester.getSemantics(find.byType(WInput));
+        expect(node.flagsCollection.isEnabled, Tristate.isTrue);
       });
 
       // CRITICAL password regression test — locks the contract Step 9's


### PR DESCRIPTION
Accessibility regression found in a post-1.0.0 audit of the WInput Material-free rewrite (#106).

## Problem

1.0.0's Material `TextField` exposed `Semantics(enabled: widget.enabled)`, so a disabled field reported `isEnabled: false` to assistive technology. The Material-free `EditableText` rewrite dropped that flag: the `EditableText` node carries only `isReadOnly` (a disabled field is routed to `readOnly: true`), so a screen reader could no longer distinguish a **disabled** field from a merely **read-only** one. The existing test even codified the gap (`isEnabled` was `Tristate.none`).

## Fix

Pass `enabled: widget.enabled` to the outer `Semantics` node that already attaches the label (`w_input.dart`). It merges into the EditableText `textField` node (non-container, `explicitChildNodes: false`), so the single-clean-node design from W1 is preserved while restoring the enabled-state cue:

- disabled field: `isEnabled == Tristate.isFalse` (plus `isReadOnly` as before)
- enabled field: `isEnabled == Tristate.isTrue`

Also documents in the `WInput` class docstring that interactive selection requires an `Overlay` ancestor (suppressed, not thrown, under a bare root) and that `onTap` fires on a tap anywhere in the box. These behaviors already shipped in #106 and were noted in the CHANGELOG; this surfaces them in the API docs too.

## Tests

`w_input_test.dart` Semantics group: the disabled test now asserts `isEnabled == Tristate.isFalse` alongside `isReadOnly`, and a new test asserts an enabled field reports `Tristate.isTrue` (so the disabled assertion is a real distinction, not a constant). The stale NOTE documenting the old behavior is corrected.

## DoD

- `dart format --set-exit-if-changed .`: clean
- `dart analyze`: no issues
- `flutter test`: 1429 pass, 1 pre-existing skip
- `./tool/coverage.sh 90`: 91.2%