### PR TITLE
ci(workflows): pin actions to commit SHAs for zizmor unpinned-uses

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,9 +17,9 @@ jobs:
     name: Diff CVEs on PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     name: Workflows lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: actionlint
         uses: docker://rhysd/actionlint:1.7.7
@@ -35,10 +35,10 @@ jobs:
     name: Lint & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
@@ -80,7 +80,7 @@ jobs:
     outputs:
       demo: ${{ steps.filter.outputs.demo }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 2
 
@@ -108,10 +108,10 @@ jobs:
     if: github.event_name == 'push' && needs.changes.outputs.demo == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
@@ -140,7 +140,7 @@ jobs:
           ../tool/stamp-demo-cache-bust.sh build/web
 
       - name: Upload Demo artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: demo-build
           path: example/build/web/
@@ -154,7 +154,7 @@ jobs:
     environment: Demo Production
     steps:
       - name: Download Demo artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: demo-build
           path: demo-build/

--- a/.github/workflows/dispatch-to-registry.yml
+++ b/.github/workflows/dispatch-to-registry.yml
@@ -31,7 +31,7 @@ jobs:
     dispatch:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   fetch-depth: 1
 
@@ -54,7 +54,7 @@ jobs:
 
             - name: Mint App token scoped to fluttersdk/ai
               id: app-token
-              uses: tibdex/github-app-token@v2.1.0
+              uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
               with:
                   app_id: ${{ secrets.REGISTRY_BOT_APP_ID }}
                   private_key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
@@ -63,7 +63,7 @@ jobs:
                   repositories: '["ai"]'
 
             - name: Fire repository_dispatch to fluttersdk/ai
-              uses: peter-evans/repository-dispatch@v4
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   repository: fluttersdk/ai

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,16 +17,16 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,13 +17,13 @@ jobs:
     name: zizmor SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - id: zizmor
-        uses: zizmorcore/zizmor-action@v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
 
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ${{ steps.zizmor.outputs.output-file }}


### PR DESCRIPTION
## What

Pin every third-party GitHub Action in all 7 workflow files to a 40-char commit SHA with the version tag preserved as a trailing comment. This resolves all 21 high `unpinned-uses` findings that zizmor was raising on CI.

## Why

zizmor enforces a blanket policy that every `uses:` reference must be a full commit SHA, not a version tag. The floating tags were producing 21 high severity `unpinned-uses` findings, causing CI to fail on every PR that touched workflows.

## SHAs pinned

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | v7 | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
| `actions/dependency-review-action` | v5 | `a1d282b36b6f3519aa1f3fc636f609c47dddb294` |
| `actions/upload-artifact` | v7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact` | v8 | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `dependabot/fetch-metadata` | v3 | `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` |
| `github/codeql-action/upload-sarif` | v4 | `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` |
| `ossf/scorecard-action` | v2.4.3 | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` |
| `peter-evans/repository-dispatch` | v4 | `28959ce8df70de7be546dd1250a005dd32156697` |
| `subosito/flutter-action` | v2 | `1a449444c387b1966244ae4d4f8c696479add0b2` |
| `tibdex/github-app-token` | v2.1.0 | `3beb63f4bd073e61482598c45c71c1019b59b73a` |
| `zizmorcore/zizmor-action` | v0.5.7 | `192e21d79ab29983730a13d1382995c2307fbcaa` |

## Dependabot supersessions

This PR incorporates the bumps from two open dependabot PRs and supersedes both:

- **Supersedes #113**: `actions/checkout` v6 -> v7 (8 occurrences across 5 workflow files, all now pinned to v7 SHA)
- **Supersedes #114**: `zizmorcore/zizmor-action` v0.5.6 -> v0.5.7 (pinned to v0.5.7 SHA in `zizmor.yml`)

## Verification

`uvx zizmor .github/workflows/` before: 21 high `unpinned-uses` findings.

`uvx zizmor .github/workflows/` after: 0 `unpinned-uses` findings. Remaining findings are pre-existing `dangerous-triggers` (1 high, `dependabot-auto-merge.yml` uses `pull_request_target`) and `artipacked` warnings (6 medium), none of which are new.

No workflow logic, steps, permissions, or triggers were modified: only `@tag` references replaced with `@sha # tag`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions in continuous integration and deployment workflows to use pinned commit references across dependency management, testing, code quality analysis, and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->