### PR TITLE
release: 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-06-23
+
 ### Changed
 
 - `WInput`: tap-to-focus and `onTap` dispatch now flow through Flutter's native `TextSelectionGestureDetectorBuilder` (the same gesture path `TextField` uses) instead of a hand-built whole-box `GestureDetector`. `onTap` continues to fire when the user taps the field; the change is the gesture mechanism (which also brings drag-select and double-tap word selection), not a new `onTap` contract.
@@ -131,6 +133,7 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.1.1...HEAD
+[1.1.1]: https://github.com/fluttersdk/wind/releases/tag/1.1.1
 [1.1.0]: https://github.com/fluttersdk/wind/releases/tag/1.1.0
 [1.0.0]: https://github.com/fluttersdk/wind/releases/tag/1.0.0

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.1.0/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.1.1/%f%#L%l%'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+1
+version: 1.1.1+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 22 W-prefix widgets, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.1.0 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 22 W-prefix widgets, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.1.1 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.1.0
+version: 1.1.1
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues


### PR DESCRIPTION
Patch release **1.1.1**.

## Release steps done in this PR
- Bumped `pubspec.yaml` version `1.1.0` -> `1.1.1`.
- Promoted `## [Unreleased]` to `## [1.1.1] - 2026-06-23` in `CHANGELOG.md`, with the trailing `[1.1.1]` link reference and the `[Unreleased]` compare link redirected to `1.1.1...HEAD`.
- Full Definition of Done gate passed: `dart analyze` clean, `dart format` no diff, `flutter test` 1443 pass (1 pre-existing skip), `./tool/coverage.sh 90` -> 91.2%.

## What ships in 1.1.1

### Fixed
- `WInput` native text selection restored: mouse drag-select, double-tap word, and long-press work again (the Material-free rewrite in #106 had dropped the selection gesture layer; only keyboard select-all worked, and web drag selected nothing). Wired via `TextSelectionGestureDetectorBuilder` + `rendererIgnoresPointer: true`; handles stay Cupertino-style on all platforms, keeping `WInput` cupertino-only with no `package:flutter/material.dart` import. (#116)
- `WText` with no color in its own `className` now inherits an ancestor `DefaultTextStyle` color (the CSS text-color cascade) before falling back to the platform-brightness baseline. (#112)

### Changed
- `WInput` tap-to-focus and `onTap` dispatch now flow through Flutter's native gesture builder instead of a hand-built `GestureDetector` (also brings drag-select and double-tap word selection). (#116)

## After merge
Tag and publish (manual, per repo process):

```
git tag 1.1.1 && git push origin 1.1.1
```

The tag triggers `.github/workflows/publish.yml` to push to pub.dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.1.1 with documentation and configuration updates across all project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->