### PR TITLE
release: 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-06-25
+
 ### Fixed
 
 - `WPopover` now opens reliably when `triggerBuilder` returns an interactive widget (a `WButton` or `WAnchor` with its own `onTap`), and no longer dismisses itself on the same gesture that opened it. Two defects were in play. First, the trigger was wired through an outer `GestureDetector(onTap: toggle)`; an interactive trigger owns its own `GestureDetector`, won the gesture arena, and the outer `onTap` never fired, so the popover never opened. The trigger now toggles through a `Listener(onPointerDown:)`, whose pointer events bypass the tap arena entirely, so opening works regardless of the trigger's interactivity (`enableTriggerOnTap` and `disabled` semantics are unchanged). Second, because the trigger and overlay share a `TapRegion` group id (intentionally, so a trigger re-tap does not self-close), the opening gesture's pointer-up reached the freshly mounted overlay's `onTapOutside` and dismissed the popover on the frame it opened. A one-shot, post-frame guard now swallows exactly that first outside-tap; a genuine, later outside tap still closes the popover. (`lib/src/widgets/w_popover.dart`; covered by `test/widgets/w_popover/gesture_regression_test.dart`, the four-behavior regression set parameterized over `WButton` and `WDiv` triggers.) Because the pointer `Listener` is invisible to assistive technologies, the trigger is wrapped in `Semantics(button: true, onTap: ...)` so screen readers and keyboard activation still reach the toggle, and the pointer toggle is filtered to the primary button so a secondary (right) click no longer opens the popover.
@@ -137,7 +139,8 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.1.1...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.1.2...HEAD
+[1.1.2]: https://github.com/fluttersdk/wind/releases/tag/1.1.2
 [1.1.1]: https://github.com/fluttersdk/wind/releases/tag/1.1.1
 [1.1.0]: https://github.com/fluttersdk/wind/releases/tag/1.1.0
 [1.0.0]: https://github.com/fluttersdk/wind/releases/tag/1.0.0

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.1.1/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.1.2/%f%#L%l%'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+1
+version: 1.1.2+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 22 W-prefix widgets, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.1.1 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 22 W-prefix widgets, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.1.2 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.1.1
+version: 1.1.2
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues


### PR DESCRIPTION
Patch release **1.1.2**.

## Release steps done in this PR
- Bumped `pubspec.yaml` version `1.1.1` -> `1.1.2`.
- Promoted `## [Unreleased]` to `## [1.1.2] - 2026-06-25` in `CHANGELOG.md`, with the trailing `[1.1.2]` link reference and the `[Unreleased]` compare link redirected to `1.1.2...HEAD`.
- Synced version references in `example/pubspec.yaml` (`1.1.2+1`), `dartdoc_options.yaml` (source-link tag), and `llms.txt` (version string).
- Full Definition of Done gate passed: `dart analyze` clean, `dart format` no diff, `flutter test` 1455 pass (1 pre-existing skip), `./tool/coverage.sh 90` -> 91.3%.

## What ships in 1.1.2

### Fixed
- `WPopover` now opens reliably when `triggerBuilder` returns an interactive widget (a `WButton` or `WAnchor` with its own `onTap`) and no longer dismisses itself on the same gesture that opened it. The trigger toggles through a `Listener(onPointerDown:)` (filtered to the primary button) to bypass the gesture arena, and a one-shot post-frame guard swallows the opening gesture's own first outside-tap. The trigger is wrapped in `Semantics(button: true, onTap: ...)` so screen readers and keyboard activation still reach the toggle. Covered by `test/widgets/w_popover/gesture_regression_test.dart` (four-behavior regression set over `WButton` and `WDiv` triggers, plus co-fire, controller-open, accessibility, and secondary-button paths). (#118)

## After merge
Tag and publish (manual, per repo process):

```
git tag 1.1.2 && git push origin 1.1.2
```

The tag triggers `.github/workflows/publish.yml` to push to pub.dev.