### PR TITLE
fix(theme): tolerate unknown spacing tokens instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Unknown theme-spacing tokens (`p-primary`, `m-foo`, `top-abc`, `gap-x-blue`, ...) now silently drop instead of throwing `ArgumentError: Invalid spacing multiplier: <token>` inside `build()`, matching the "unknown className is dropped with a debug warning" contract other parsers already follow. Adds `WindThemeData.tryGetSpacing(String)`; the padding, margin, position, and flex-gap parsers now use it (sizing already pre-validated with `double.tryParse`). `getSpacing` is unchanged for backward compatibility. (`lib/src/theme/wind_theme_data.dart`, `lib/src/parser/parsers/padding_parser.dart`, `lib/src/parser/parsers/margin_parser.dart`, `lib/src/parser/parsers/position_parser.dart`, `lib/src/parser/parsers/flexbox_grid_parser.dart`)
 - `WAnchor` now hit-tests its whole bounds via `HitTestBehavior.translucent`. The inner `GestureDetector` used the default `HitTestBehavior.deferToChild`, so it only fired when a painted child sat under the exact tap point. An anchor wrapping transparent content (a settings row, a checkbox row, a link with padding) ignored taps that landed on its empty regions, including the element centre that automated drivers and centred pointer events target. It now behaves like `WInput`/`WPopover`, which already use whole-box hit-testing, so the full anchor rectangle is tappable. (`lib/src/widgets/w_anchor.dart`; covered by `test/widgets/w_anchor_test.dart`)
 
 ## [1.2.0] - 2026-07-08

--- a/lib/src/parser/parsers/flexbox_grid_parser.dart
+++ b/lib/src/parser/parsers/flexbox_grid_parser.dart
@@ -323,7 +323,9 @@ class FlexboxGridParser implements WindParserInterface {
           final match = _themeGapRegex.firstMatch(className);
           if (match != null) {
             root = match.namedGroup('root')!;
-            value = theme.getSpacing(match.namedGroup('value')!);
+            // Use `tryGetSpacing` so an unknown token (e.g. `gap-x-blue`)
+            // is dropped by the null-guard below rather than throwing.
+            value = theme.tryGetSpacing(match.namedGroup('value')!);
           }
         }
 

--- a/lib/src/parser/parsers/margin_parser.dart
+++ b/lib/src/parser/parsers/margin_parser.dart
@@ -96,8 +96,9 @@ class MarginParser implements WindParserInterface {
         // Skip 'auto' value - it's handled by mx-auto
         if (valueKey == 'auto') continue;
 
-        // Call the theme's `getSpacing` method
-        value = theme.getSpacing(valueKey);
+        // Use `tryGetSpacing` so an unknown token (e.g. `m-foo`) is dropped
+        // by the null-guard below rather than throwing at build.
+        value = theme.tryGetSpacing(valueKey);
       }
 
       if (value == null || root == null) continue;

--- a/lib/src/parser/parsers/padding_parser.dart
+++ b/lib/src/parser/parsers/padding_parser.dart
@@ -82,8 +82,9 @@ class PaddingParser implements WindParserInterface {
         root = match.namedGroup('root')!;
         final valueKey = match.namedGroup('value')!; // "4", "1/2"
 
-        // Call the theme's `getSpacing` method
-        value = theme.getSpacing(valueKey);
+        // Use `tryGetSpacing` so an unknown token (e.g. `p-primary`) is
+        // dropped by the null-guard below rather than throwing at build.
+        value = theme.tryGetSpacing(valueKey);
       }
 
       if (value == null || root == null) continue;

--- a/lib/src/parser/parsers/position_parser.dart
+++ b/lib/src/parser/parsers/position_parser.dart
@@ -97,7 +97,9 @@ class PositionParser implements WindParserInterface {
         if (themeMatch != null) {
           root = themeMatch.namedGroup('root')!;
           final valueKey = themeMatch.namedGroup('value')!;
-          value = theme.getSpacing(valueKey);
+          // Use `tryGetSpacing` so an unknown token (e.g. `top-abc`) is
+          // dropped by the null-guard below rather than throwing at build.
+          value = theme.tryGetSpacing(valueKey);
         }
       }
 

--- a/lib/src/theme/wind_theme_data.dart
+++ b/lib/src/theme/wind_theme_data.dart
@@ -320,6 +320,24 @@ class WindThemeData {
     }
   }
 
+  /// Same as [getSpacing] but returns `null` for an unrecognized [multiplier]
+  /// instead of throwing.
+  ///
+  /// Parsers should prefer this so an unknown token (e.g. `p-primary` — a
+  /// color-name typo the padding parser's regex still admits) is silently
+  /// dropped in line with the "unknown className is dropped with a debug
+  /// warning" contract, rather than surfacing as an `ArgumentError` inside
+  /// a `build()` call.
+  double? tryGetSpacing(String multiplier) {
+    if (multiplier == 'full') return double.infinity;
+    if (containers.containsKey(multiplier)) {
+      return containers[multiplier]!.toDouble() * baseSpacingUnit;
+    }
+    final value = double.tryParse(multiplier);
+    if (value == null) return null;
+    return value * baseSpacingUnit;
+  }
+
   /// Creates a copy of this theme data but with the given fields replaced.
   ///
   /// Example:

--- a/lib/src/theme/wind_theme_data.dart
+++ b/lib/src/theme/wind_theme_data.dart
@@ -303,27 +303,17 @@ class WindThemeData {
   /// - `getSpacing('md')` returns the spacing for the 'md' container.
   /// - `getSpacing('full')` returns `double.infinity`.
   double getSpacing(String multiplier) {
-    // Handle special 'full' case
-    if (multiplier == 'full') {
-      return double.infinity;
+    final spacing = tryGetSpacing(multiplier);
+    if (spacing == null) {
+      throw ArgumentError('Invalid spacing multiplier: $multiplier');
     }
-
-    if (containers.containsKey(multiplier)) {
-      return containers[multiplier]!.toDouble() * baseSpacingUnit;
-    } else {
-      final value = double.tryParse(multiplier);
-      if (value != null) {
-        return value * baseSpacingUnit;
-      } else {
-        throw ArgumentError('Invalid spacing multiplier: $multiplier');
-      }
-    }
+    return spacing;
   }
 
   /// Same as [getSpacing] but returns `null` for an unrecognized [multiplier]
   /// instead of throwing.
   ///
-  /// Parsers should prefer this so an unknown token (e.g. `p-primary` — a
+  /// Parsers should prefer this so an unknown token (e.g. `p-primary`, a
   /// color-name typo the padding parser's regex still admits) is silently
   /// dropped in line with the "unknown className is dropped with a debug
   /// warning" contract, rather than surfacing as an `ArgumentError` inside

--- a/test/parser/parsers/flexbox_grid_parser_test.dart
+++ b/test/parser/parsers/flexbox_grid_parser_test.dart
@@ -425,5 +425,19 @@ void main() {
         );
       });
     });
+
+    group('unknown theme gap tokens', () {
+      test('drops gap-<unknown-token> silently instead of throwing', () {
+        final classes = ['gap-blue', 'gap-x-primary', 'gap-y-foo'];
+
+        expect(
+          () => parser.parse(WindStyle(), classes, context),
+          returnsNormally,
+        );
+        final styles = parser.parse(WindStyle(), classes, context);
+        expect(styles.gapX, isNull);
+        expect(styles.gapY, isNull);
+      });
+    });
   });
 }

--- a/test/parser/parsers/margin_parser_test.dart
+++ b/test/parser/parsers/margin_parser_test.dart
@@ -140,5 +140,18 @@ void main() {
         expect(parser.canParse(''), isFalse);
       });
     });
+
+    group('unknown theme tokens', () {
+      test('drops m-<unknown-token> silently instead of throwing', () {
+        final styles = WindStyle();
+        final classes = ['m-primary', 'mx-foo', 'my-bar'];
+
+        expect(
+          () => parser.parse(styles, classes, context),
+          returnsNormally,
+        );
+        expect(parser.parse(styles, classes, context).margin, isNull);
+      });
+    });
   });
 }

--- a/test/parser/parsers/padding_parser_test.dart
+++ b/test/parser/parsers/padding_parser_test.dart
@@ -129,5 +129,18 @@ void main() {
         expect(parser.canParse(''), isFalse);
       });
     });
+
+    group('unknown theme tokens', () {
+      test('drops p-<unknown-token> silently instead of throwing', () {
+        final styles = WindStyle();
+        final classes = ['p-primary', 'mx-foo', 'py-bar'];
+
+        expect(
+          () => parser.parse(styles, classes, context),
+          returnsNormally,
+        );
+        expect(parser.parse(styles, classes, context).padding, isNull);
+      });
+    });
   });
 }

--- a/test/parser/parsers/position_parser_test.dart
+++ b/test/parser/parsers/position_parser_test.dart
@@ -263,6 +263,22 @@ void main() {
           expect(result.positionRight, 8.0);
         });
       });
+
+      group('unknown theme tokens', () {
+        test('drops top-<unknown-token> silently instead of throwing', () {
+          final styles = WindStyle();
+          final classes = ['top-abc', 'left-foo', 'inset-x-bar'];
+
+          expect(
+            () => parser.parse(styles, classes, context),
+            returnsNormally,
+          );
+          final result = parser.parse(styles, classes, context);
+          expect(result.positionTop, isNull);
+          expect(result.positionLeft, isNull);
+          expect(result.positionRight, isNull);
+        });
+      });
     });
   });
 }

--- a/test/theme/wind_theme_data_test.dart
+++ b/test/theme/wind_theme_data_test.dart
@@ -154,6 +154,22 @@ void main() {
       // Test known spacing fraction
       expect(theme.getSpacing('full'), double.infinity);
     });
+
+    test('tryGetSpacing matches getSpacing for known tokens', () {
+      final theme = WindThemeData();
+
+      expect(theme.tryGetSpacing('4'), theme.getSpacing('4'));
+      expect(theme.tryGetSpacing('2.5'), theme.getSpacing('2.5'));
+      expect(theme.tryGetSpacing('full'), double.infinity);
+    });
+
+    test('tryGetSpacing returns null for an unknown token', () {
+      final theme = WindThemeData();
+
+      expect(theme.tryGetSpacing('primary'), isNull);
+      expect(theme.tryGetSpacing('foo'), isNull);
+      expect(theme.tryGetSpacing('abc'), isNull);
+    });
   });
 
   group('WindThemeData value equality', () {


### PR DESCRIPTION
Fixes #155

## Summary

`WindThemeData.getSpacing` throws `ArgumentError` for any `multiplier` that isn't `'full'`, a container key, or numeric. The padding, margin, position, and flex-gap parsers each pass the raw regex-captured value directly, so tokens like `p-primary`, `m-foo`, `top-abc`, `gap-x-blue` — natural typos after using `bg-primary`/`text-primary` — throw at build time and produce a red screen. This violates the parser contract at `wind_parser.dart:369` (unknown className is dropped with a debug warning); the sibling `sizing_parser.dart` already pre-validates with `double.tryParse`.

Adds `WindThemeData.tryGetSpacing(String)` — same behaviour as `getSpacing` but returns `null` for unrecognised tokens. Switches the four throwing callers to use it and drop the token via their existing `if (value == null) continue;` guards. `getSpacing` is unchanged.

## Definition of done

- [ ] `dart analyze` — please run in CI (no toolchain on audit machine).
- [ ] `dart format .` — please run in CI.
- [ ] `flutter test` — added coverage:
      - `test/theme/wind_theme_data_test.dart` — `tryGetSpacing` matches `getSpacing` for known tokens; returns `null` for unknown.
      - `test/parser/parsers/padding_parser_test.dart` — `p-primary`/`mx-foo`/`py-bar` no longer throw.
      - `test/parser/parsers/margin_parser_test.dart` — `m-primary`/`mx-foo`/`my-bar` no longer throw.
      - `test/parser/parsers/position_parser_test.dart` — `top-abc`/`left-foo`/`inset-x-bar` no longer throw.
      - `test/parser/parsers/flexbox_grid_parser_test.dart` — `gap-blue`/`gap-x-primary`/`gap-y-foo` no longer throw.
- [ ] `./tool/coverage.sh 90` — new `tryGetSpacing` is fully exercised and each patched parser gains a dedicated test, so coverage should hold at ≥ 90 %. Please confirm in CI.

## Post-change sync

This is a pure defect fix; no new widget/parser/token/theme field is added. `doc/`, `example/lib/pages/`, `skills/wind-ui/`, and `README.md` are unchanged per the guidance. CHANGELOG updated under `[Unreleased] > Fixed`.

## Notes

I could not run `flutter test`/`dart analyze`/`dart format` locally (no Flutter toolchain on the audit machine). Please rely on CI. All edits were made against HEAD `aa07198` and follow the parser conventions in `.github/instructions/parsers.instructions.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown theme spacing tokens in margin, padding, position, and gap utilities are now safely ignored instead of causing errors.
  * Valid spacing tokens continue to resolve as before, including numeric values and `full`.

* **Tests**
  * Added coverage for unknown spacing tokens across supported utility parsers and theme spacing lookups.

* **Documentation**
  * Updated the changelog with the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->