### PR TITLE
fix(widgets): WPopover first-tap flicker and WAnchor full-bounds tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `WAnchor` now hit-tests its whole bounds via `HitTestBehavior.translucent`. The inner `GestureDetector` used the default `HitTestBehavior.deferToChild`, so it only fired when a painted child sat under the exact tap point. An anchor wrapping transparent content (a settings row, a checkbox row, a link with padding) ignored taps that landed on its empty regions, including the element centre that automated drivers and centred pointer events target. It now behaves like `WInput`/`WPopover`, which already use whole-box hit-testing, so the full anchor rectangle is tappable. (`lib/src/widgets/w_anchor.dart`; covered by `test/widgets/w_anchor_test.dart`)
+- `WPopover` no longer flickers open-then-closed on the first trigger tap on web, and its menu items now respond on the first open. A leftover focus-loss auto-close (`_onFocusChange`) dismissed the popover roughly 150ms after the opening click, when web transiently blurs the trigger, so it closed on the same gesture that opened it (and unmounted the overlay before a menu item's tap could resolve). The auto-close is removed; dismissal is now driven solely by an outside tap and programmatic `close`, matching the same fix already applied to `WSelect`. (`lib/src/widgets/w_popover.dart`)
 
 ## [1.2.0] - 2026-07-08
 

--- a/lib/src/widgets/w_popover.dart
+++ b/lib/src/widgets/w_popover.dart
@@ -262,6 +262,14 @@ class WPopover extends StatefulWidget {
 class _WPopoverState extends State<WPopover> {
   final LayerLink _layerLink = LayerLink();
   final OverlayPortalController _overlayController = OverlayPortalController();
+
+  /// Focus node for the trigger. Deliberately NOT wired to a focus-loss
+  /// auto-close: on web the trigger transiently loses focus ~150ms after the
+  /// opening click, so a focus-loss close dismissed the popover on the same
+  /// gesture that opened it (and unmounted the overlay before a menu item's tap
+  /// could resolve). Dismissal is driven solely by an outside tap
+  /// ([_handleTapOutside]) and programmatic [close], mirroring the same fix
+  /// already applied to `WSelect`.
   final FocusNode _focusNode = FocusNode();
   final GlobalKey _triggerKey = GlobalKey();
 
@@ -432,7 +440,6 @@ class _WPopoverState extends State<WPopover> {
   @override
   void initState() {
     super.initState();
-    _focusNode.addListener(_onFocusChange);
     widget.controller?.addListener(_handleControllerChange);
   }
 
@@ -447,7 +454,6 @@ class _WPopoverState extends State<WPopover> {
 
   @override
   void dispose() {
-    _focusNode.removeListener(_onFocusChange);
     _focusNode.dispose();
     widget.controller?.removeListener(_handleControllerChange);
     super.dispose();
@@ -461,12 +467,6 @@ class _WPopoverState extends State<WPopover> {
       } else {
         close();
       }
-    }
-  }
-
-  void _onFocusChange() {
-    if (!_focusNode.hasFocus && _isOpen) {
-      close();
     }
   }
 


### PR DESCRIPTION
## Summary

Two web-interaction fixes for tappable widgets, surfaced while driving the UI end-to-end.

### WPopover (`fix/popover`)
- No longer flickers open-then-closed on the first trigger tap on web, and menu items respond on the first open. A leftover focus-loss auto-close (`_onFocusChange`) dismissed the popover ~150ms after the opening click, when web transiently blurs the trigger; the `_suppressNextTapOutside` guard covered only the outside-tap path, so the focus path fired unguarded and closed the popover on the same gesture that opened it (unmounting the overlay before a menu item's tap could resolve).
- The focus-loss auto-close is removed: a tap-only trigger cannot be opened by keyboard, so closing on focus loss added no real dismissal path while firing spuriously on web. Dismissal is now driven solely by outside-tap and programmatic `close`, matching the same fix already applied to `WSelect`.

### WAnchor (`fix/anchor`)
- The whole `WAnchor` bounds are now tappable via a translucent hit-test (previously only painted pixels registered the tap).

## Testing
- `flutter test test/widgets/w_popover_test.dart` green (64). The web focus-transient flicker is not reproducible in a widget harness (verified via CDP mouse events); the removal keeps every existing open/close/outside-tap test passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a web issue causing popovers to flicker closed shortly after opening.
  * Popover menu items can now be tapped on the first opening.
  * Popovers now close only when tapping outside or through a programmatic close action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->