### PR TITLE
release: 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-21
+
 ### Fixed
 
 - Unknown theme-spacing tokens (`p-primary`, `m-foo`, `top-abc`, `gap-x-blue`, ...) now silently drop instead of throwing `ArgumentError: Invalid spacing multiplier: <token>` inside `build()`, matching the "unknown className is dropped with a debug warning" contract other parsers already follow. Adds `WindThemeData.tryGetSpacing(String)`; the padding, margin, position, and flex-gap parsers now use it (sizing already pre-validated with `double.tryParse`). `getSpacing` is unchanged for backward compatibility. (`lib/src/theme/wind_theme_data.dart`, `lib/src/parser/parsers/padding_parser.dart`, `lib/src/parser/parsers/margin_parser.dart`, `lib/src/parser/parsers/position_parser.dart`, `lib/src/parser/parsers/flexbox_grid_parser.dart`)
@@ -190,7 +192,8 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.2.0...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.2.1...HEAD
+[1.2.1]: https://github.com/fluttersdk/wind/releases/tag/1.2.1
 [1.2.0]: https://github.com/fluttersdk/wind/releases/tag/1.2.0
 [1.1.2]: https://github.com/fluttersdk/wind/releases/tag/1.1.2
 [1.1.1]: https://github.com/fluttersdk/wind/releases/tag/1.1.1

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.2.0/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.2.1/%f%#L%l%'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+1
+version: 1.2.1+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.2.0 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.2.1 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.2.0
+version: 1.2.1
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues


### PR DESCRIPTION
## Summary

Prepares the **1.2.1** patch release: the three bug fixes merged since 1.2.0, now versioned.

Per SemVer 2.0.0 this is a PATCH bump (not 1.3.0): everything landed since 1.2.0 is a bug fix, with no new public API surface and no breaking change.

## What ships in 1.2.1

Bug fixes merged since 1.2.0:

- **Theme:** unknown theme-spacing tokens (`p-primary`, `m-foo`, `top-abc`, `gap-x-blue`) now drop instead of throwing `ArgumentError: Invalid spacing multiplier` inside `build()`. Adds the non-throwing `WindThemeData.tryGetSpacing`; the padding, margin, position, and flex-gap parsers use it. (#156)
- **WAnchor:** hit-tests its whole bounds via `HitTestBehavior.translucent`, so an anchor wrapping transparent content (a settings row, a link with padding) is tappable across its full rectangle, including the centre that automated drivers target. (#152)
- **WPopover:** no longer flickers open-then-closed on the first trigger tap on web, and its menu items respond on the first open. The leftover focus-loss auto-close that dismissed the overlay ~150ms after the opening click is removed. (#157)

The two CI dependency bumps (#153, #154) are dev-infra only and carry no CHANGELOG entry.

Full detail in the promoted `## [1.2.1]` CHANGELOG section.

## Release bump

`pubspec.yaml` 1.2.0 -> 1.2.1, plus the same ancillary version strings the prior release PR synced: `example/pubspec.yaml`, the `dartdoc_options.yaml` source-link tag, and the `llms.txt` version string. CHANGELOG `## [Unreleased]` promoted to `## [1.2.1] - 2026-07-21`, with the `[1.2.1]` link reference added and the `[Unreleased]` compare link redirected to `1.2.1...HEAD`.

No documentation / skill / example sync commit this time: each fix PR already synced its own surfaces per the post-change discipline, and a patch adds no new public surface (the `wind-ui` skill tracks the unchanged 1.2 minor line, so its version label stays).

## Verification

- `flutter test`: 1671 passed, 1 pre-existing skip, 0 failures.
- `./tool/coverage.sh 90`: 94.7% (gate 90%).
- `dart format --set-exit-if-changed` clean; `dart analyze` clean on `lib/` and `test/`.

## After merge

Tag `1.2.1` and push it to trigger `publish.yml` to pub.dev.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown theme-spacing tokens are now ignored instead of causing errors.
  * Anchor hit-testing now covers the complete clickable area.
  * Popovers no longer unexpectedly close or flicker on the first web trigger tap.

* **Release**
  * Updated the package and example app to version 1.2.1.
  * Updated documentation and release references for version 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->