### PR TITLE
ci(deps): stop dependabot tracking the parent package in example/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,14 @@ updates:
       - dependency-name: google_fonts
         update-types:
           - version-update:semver-major
+      # fluttersdk_wind is the parent package, consumed through `path: ../` so
+      # the gallery always builds against the working tree. Dependabot reads
+      # the resolved version of that path package and proposes it as a
+      # `version:` pin, which is a hard equality constraint on a moving target:
+      # it goes stale on the next release and fails resolution outright
+      # ("depends on fluttersdk_wind X from path which doesn't match any
+      # versions"). See #159. There is no valid update here, so never track it.
+      - dependency-name: fluttersdk_wind
 
   # ─────────────────────────────────────────────────────────────────────
   # GitHub Actions under .github/workflows/


### PR DESCRIPTION
Follow-up to #159, which I closed as unmergeable.

## The problem

`example/pubspec.yaml` consumes the parent through a path dependency:

```yaml
  fluttersdk_wind:
    path: ../
```

That is deliberate. The gallery builds against the working tree, which is what makes it the manual smoke test for unreleased code (`example/CLAUDE.md`). Dependabot's pub ecosystem, pointed at `/example`, reads the *resolved* version of that path package and proposes it back as a `version:` pin. A pin is a hard equality constraint on a number that changes every release, so the PR is stale the moment it is opened and fails resolution rather than a test:

```
$ flutter pub get
Because fluttersdk_wind_example depends on fluttersdk_wind 1.2.1 from path
which doesn't match any versions, version solving failed.
```

Reproduced locally against the 1.3.0 release branch (#165). #159's own CI was green only because it opened on 2026-08-01, while the parent still happened to be 1.2.1.

## The change

One `ignore` entry in the `/example` pub block. No `update-types` filter: there is no update to this dependency that would ever be valid, since the version is whatever the checkout says. Everything else in the `example-minor-and-patch` group is untouched, and the existing `google_fonts` major-version ignore is unchanged.

Validated that the file still parses and the entry lands in the right block:

```
ignore entries: [{'dependency-name': 'google_fonts', 'update-types': ['version-update:semver-major']},
                 {'dependency-name': 'fluttersdk_wind'}]
```

## Unrelated issue worth a separate look

`Auto-merge low-risk Dependabot PRs` has been failing on every actions bump (#160 to #163) with:

```
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests.
```

That is the repo/org setting "Allow GitHub Actions to create and approve pull requests", not a workflow bug. While it is off, the auto-merge job can never pass, and since `master` requires one approving review, every dependabot PR needs a human. Worth either enabling the setting or dropping the approve step and letting `--auto` wait for a human review.