### PR TITLE
release: 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ---
 
-## [Unreleased]
+## [1.4.0] - 2026-08-21
 
 ### Added
 
@@ -40,6 +40,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 - `doc/utilities/context-extensions.md` demonstrated `context.windTheme.setBrightness(Brightness.dark)`, a method `WindThemeController` has never exposed, so a reader following the page hit a compile error. Replaced with the two calls that actually pin a preference: `toggleTheme()` (which sets `syncWithSystem: false` itself) and `setTheme(data.copyWith(brightness: ..., syncWithSystem: false))`, plus `resetToSystem()` to hand control back. A bare `updateTheme(brightness: ...)` is the partial-update call the framework's own `didChangePlatformBrightness` listener makes, so with `syncWithSystem` still true the next OS change overwrites it. (`doc/utilities/context-extensions.md`)
 - `llms.txt` pointed `WFormMultiSelect` at `widgets/w-form-multiselect.md`, which does not exist; the widget is documented inside `w-form-select.md`. (`llms.txt`)
 - The README acceptance criterion in `CLAUDE.md` still named the pre-1.2.0 roster (22 widgets, 19 parsers), which is what a future session would have synced the README back to. It now matches the shipped surface (27 widgets, 20 parsers, 24 theme fields). (`CLAUDE.md`)
+- Release surfaces moved to the 1.4 line in one pass: `pubspec.yaml`, `example/pubspec.yaml`, the `dartdoc_options.yaml` source-link tag (which pins generated dartdoc line links to the release tag, so a stale value points readers at the previous release's line numbers), the `llms.txt` version string, and the nine `skills/wind-ui/references/*.md` H1s plus the SKILL.md description and version marker. The skill titles are the ones that rot quietly: they lagged a release twice already, at 1.2.0 and again at 1.3.0. (`pubspec.yaml`, `example/pubspec.yaml`, `dartdoc_options.yaml`, `llms.txt`, `skills/wind-ui/`)
 
 ## [1.3.0] - 2026-08-03
 
@@ -243,7 +244,8 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.3.0...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.4.0...HEAD
+[1.4.0]: https://github.com/fluttersdk/wind/releases/tag/1.4.0
 [1.3.0]: https://github.com/fluttersdk/wind/releases/tag/1.3.0
 [1.2.1]: https://github.com/fluttersdk/wind/releases/tag/1.2.1
 [1.2.0]: https://github.com/fluttersdk/wind/releases/tag/1.2.0

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.3.0/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.4.0/%f%#L%l%'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.0+1
+version: 1.4.0+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.3.0 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.4.0 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.3.0
+version: 1.4.0
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wind-ui
-description: "fluttersdk_wind 1.3: utility-first Flutter styling with Tailwind-syntax className strings. 27 W-prefix widgets (WDiv, WText, WButton, WInput, WSelect, WDatePicker, WPopover, WCard, WTabs, plus five WForm* wrappers) parse className into a cached immutable WindStyle; WindRecipe and WindSlotRecipe compose variant classNames. Prefixes stack freely (dark: / hover: / focus: / md: / ios: / selected: / disabled: / custom), the last class in a family wins, an unrecognized token drops with a one-time kDebugMode hint, and every color token carries a dark: peer in the same className. TRIGGER when: writing or editing UI in a Flutter app that depends on fluttersdk_wind; any className string; any W-prefix widget; any WindTheme or WindThemeData reference; the user mentions Tailwind for Flutter, utility-first, className, or wind-ui. DO NOT TRIGGER when: backend, API, or state-management work that never touches a widget tree; a Flutter project without fluttersdk_wind in pubspec.yaml; Material-only widgets (Scaffold, AppBar, Dialog) with no Wind content inside."
+description: "fluttersdk_wind 1.4: utility-first Flutter styling with Tailwind-syntax className strings. 27 W-prefix widgets (WDiv, WText, WButton, WInput, WSelect, WDatePicker, WPopover, WCard, WTabs, plus five WForm* wrappers) parse className into a cached immutable WindStyle; WindRecipe and WindSlotRecipe compose variant classNames. Prefixes stack freely (dark: / hover: / focus: / md: / ios: / selected: / disabled: / custom), the last class in a family wins, an unrecognized token drops with a one-time kDebugMode hint, and every color token carries a dark: peer in the same className. TRIGGER when: writing or editing UI in a Flutter app that depends on fluttersdk_wind; any className string; any W-prefix widget; any WindTheme or WindThemeData reference; the user mentions Tailwind for Flutter, utility-first, className, or wind-ui. DO NOT TRIGGER when: backend, API, or state-management work that never touches a widget tree; a Flutter project without fluttersdk_wind in pubspec.yaml; Material-only widgets (Scaffold, AppBar, Dialog) with no Wind content inside."
 when_to_use: "Any task that produces, modifies, or audits Wind-styled UI: composing a className, picking the right W-widget, wiring a Form field, customizing WindThemeData, pairing dark-mode classes, debugging a layout or a RenderFlex overflow, building a popover, rendering a JSON tree via WDynamic, or composing a WindRecipe. Load it before the first line of new UI, and equally when auditing UI that already exists."
 version: 2.12.0
 ---
 
-<!-- fluttersdk_wind 1.3.x | Skill v2.12.0 (2026-08-21) -->
+<!-- fluttersdk_wind 1.4.x | Skill v2.12.0 (2026-08-21) -->
 
 # Wind UI 1.3
 

--- a/skills/wind-ui/references/debug.md
+++ b/skills/wind-ui/references/debug.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Debug bridge, parser cache, logger
+# Wind 1.4: Debug bridge, parser cache, logger
 
 Wiring `Wind.installDebugResolver()` for E2E tooling (Dusk, Telescope, Playwright), understanding the parser cache (and why tests need `WindParser.clearCache()`), and reading `WindLogger` output for performance / composition debugging.
 

--- a/skills/wind-ui/references/design-culture.md
+++ b/skills/wind-ui/references/design-culture.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Design culture
+# Wind 1.4: Design culture
 
 Taste, expressed as className tokens. Every other reference file answers "does this token exist and what does it do"; this one answers "which token should this be". Reach for it when the task is a screen or a component with no design spec attached, when a layout renders correctly and still looks wrong, or when a reviewer says "it works but it feels off".
 

--- a/skills/wind-ui/references/dynamic.md
+++ b/skills/wind-ui/references/dynamic.md
@@ -1,4 +1,4 @@
-# Wind 1.3: WDynamic (server-driven UI)
+# Wind 1.4: WDynamic (server-driven UI)
 
 JSON node tree → Wind widget tree. Reach for this file when rendering UI from a CMS, A/B framework, remote-config service, or any source where the widget shape is decided at runtime.
 

--- a/skills/wind-ui/references/forms.md
+++ b/skills/wind-ui/references/forms.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Forms
+# Wind 1.4: Forms
 
 Building forms with validation. Use this file when picking between raw `W*` and `WForm*`, wiring `FormState.validate()`, handling async / server-side errors, or working around the WFormDatePicker range gotcha.
 

--- a/skills/wind-ui/references/layouts.md
+++ b/skills/wind-ui/references/layouts.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Layouts
+# Wind 1.4: Layouts
 
 12+ canonical layout recipes plus the Flutter constraint model that drives every overflow. Reach for this file when picking a layout pattern or recovering from RenderFlex / unbounded-height assertions.
 

--- a/skills/wind-ui/references/tailwind-divergence.md
+++ b/skills/wind-ui/references/tailwind-divergence.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Wind ≠ Tailwind divergence catalog
+# Wind 1.4: Wind ≠ Tailwind divergence catalog
 
 Comprehensive map of where Wind diverges from Tailwind CSS v3 and v4. Reach for this file when migrating a className from web, recovering from a "this token does not seem to do anything" stall, or auditing a Tailwind-trained codebase.
 

--- a/skills/wind-ui/references/theme.md
+++ b/skills/wind-ui/references/theme.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Theme, dark mode, responsive, platform
+# Wind 1.4: Theme, dark mode, responsive, platform
 
 Customizing `WindThemeData`, brightness control, breakpoint scale, platform prefixes. Reach for this file when adding custom colors, overriding the spacing scale, wiring a dark-mode toggle, defining a custom breakpoint, or recovering from the OverlayEntry context caveat.
 

--- a/skills/wind-ui/references/tokens.md
+++ b/skills/wind-ui/references/tokens.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Token catalog
+# Wind 1.4: Token catalog
 
 Exhaustive per-parser token reference. Reach for this file when verifying a className token exists, picking the right family, looking up an arbitrary-value pattern, or auditing className for unsupported syntax.
 

--- a/skills/wind-ui/references/widgets.md
+++ b/skills/wind-ui/references/widgets.md
@@ -1,4 +1,4 @@
-# Wind 1.3: Widget reference
+# Wind 1.4: Widget reference
 
 Full constructor surface, every named parameter, every default. Reach for this file when picking a widget, wiring callbacks, or recovering from a "what does this prop do?" stall.
 


### PR DESCRIPTION
## Why 1.4.0 and not 1.3.1

The release was asked for as a patch. It is a minor, and the reason is one entry in the log.

`WInput` moved its single-line Return-key default from `TextInputAction.next` to `.done` (#177). That changes behaviour in every consumer that never passed `textInputAction`, and consumers are pinned with `^1.3.0`, so a patch would have landed it on all of them at the next `pub upgrade` with the version number saying nothing had changed. A patch release is a promise that the upgrade is invisible, and this one is not: a form whose fields happen to sit next to each other in traversal order silently loses Return-advances-field.

A minor still reaches everyone automatically under `^1.3.0`, so the two layout fixes are not withheld from anyone, but the number now tells a reader to open the notes. `2.0.0` was the other candidate and was rejected as disproportionate for one keyboard default: it would strand every `^1.3.0` consumer on 1.3.x, so the two real layout fixes would reach nobody.

## What ships

**Changed (behavioural break)**
- `WInput` single-line Return key defaults to `.done`, multiline still `.newline`, an explicit `textInputAction` still wins. Path back for a form that relied on the old default: pass `textInputAction: TextInputAction.next` per field. (#177)

**Fixed**
- A `justify-between` row no longer splits its width between a child that asked to grow and siblings that did not. (#175)
- `WKeyboardActions` hosts its toolbar in the root overlay, so it lands on the keyboard instead of hundreds of points below the viewport. (#176)

**Added**
- `skills/wind-ui/references/design-culture.md`, the taste layer the skill never had.

**Quality**
- The CI fix that had every open PR red on a dirty checkout (#178), the codeql-action bump (#174), the branch-lifetime policy, the docs link gate, and the Dependabot auto-merge repair.

## Release mechanics

Following the shape of the 1.3.0 release commit, six surfaces move together:

| File | Change |
|---|---|
| `pubspec.yaml` | `1.3.0` -> `1.4.0` |
| `example/pubspec.yaml` | `1.3.0+1` -> `1.4.0+1` |
| `dartdoc_options.yaml` | source-link tag `blob/1.3.0` -> `blob/1.4.0` |
| `llms.txt` | `Version 1.3.0 stable` -> `Version 1.4.0 stable` |
| `CHANGELOG.md` | `## [Unreleased]` -> `## [1.4.0] - 2026-08-21`, `[1.4.0]` link reference added, `[Unreleased]` compare redirected to `1.4.0...HEAD` |
| `skills/wind-ui/` | nine reference H1s plus the SKILL.md description and version marker moved to the 1.4 line |

`dartdoc_options.yaml` is the one that hides: it pins generated dartdoc line links to the release tag, so a stale value points readers at the previous release's line numbers. It was found by diffing the 1.3.0 release commit rather than by grepping for the version, which had missed it.

The skill titles are the ones that rot quietly. They lagged a release twice already, at 1.2.0 and again at 1.3.0.

## Gates

Run locally on the branch tip:

- `dart format --set-exit-if-changed`: 0 changed.
- `dart analyze lib/ test/ example/lib/`: No issues found.
- `./tool/coverage.sh 90`: 1698 passed, 1 skipped, coverage 94.8%.
- `python3 tool/check-docs.py`: 0 issues across 72 doc pages.
- `dart pub publish --dry-run` on a clean tree: `Package has 0 warnings and 1 hint`. The hint is the gitignored local `pubspec_overrides.yaml`, which does not exist in CI. Archive is 1 MB and carries no build output or coverage artifacts.

## After merge

`git tag 1.4.0 && git push origin 1.4.0` triggers `publish.yml` and pushes to pub.dev. That step is not reversible (pub.dev retracts, it does not unpublish), so it stays a deliberate human action.