### PR TITLE
release: 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ---
 
-## [Unreleased]
+## [1.4.1] - 2026-08-23
 
 ### Fixed
 
@@ -27,6 +27,8 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 - **The registry sync now skips a prerelease tag, so a beta release does not hand beta skill content to every consumer.** `publish.yml`'s tag filter is `[0-9]+.[0-9]+.[0-9]+*`, so `1.5.0-beta.1` matches it and this repo has shipped `1.0.0-alpha.*` tags. The reason to skip is distribution rather than a malformed version: `fluttersdk/ai`'s `sync.yml` validates the upstream version as `^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?$` (a prerelease is explicitly allowed) and derives its own version by bumping its own manifest's patch number, so the string sent only reaches its release notes. What a sync does do is rsync `skills/wind-ui/` onto the registry's `main`, which is what `npx skills add fluttersdk/ai` serves. A branch name containing a dash cannot trip the guard, because on a `workflow_dispatch` the `github-release` job is skipped by its own tag check and a dependant of a skipped job is skipped with it. (`.github/workflows/publish.yml`)
 
 - **The called workflow's checkout stops carrying a token it does not use.** It now sets `persist-credentials: false` like every other checkout here: the job only reads `pubspec.yaml`, zizmor's `artipacked` audit is on by default, and this change is what puts the workflow inside the release pipeline. (`.github/workflows/dispatch-to-registry.yml`)
+
+- **The skill's own title had been reading `Wind UI 1.3` since the 1.4.0 release, and the release checklist is why.** That checklist names three version spots in `skills/wind-ui/`: the nine `references/*.md` H1s, the SKILL.md `description` prefix, and the `<!-- fluttersdk_wind X.Y.x | Skill vN -->` marker. There is a fourth, SKILL.md's own H1 on line 10, and nothing pointed at it, so 1.4.0 moved the other three and left this one behind. It is the first line of the file an agent loads. Corrected here with the rest of the 1.4.1 surface pass (`pubspec.yaml`, `example/pubspec.yaml`, the `dartdoc_options.yaml` source-link tag, the `llms.txt` version string); the nine reference H1s and the marker already read `1.4` and need no change for a patch. (`skills/wind-ui/SKILL.md`, `pubspec.yaml`, `example/pubspec.yaml`, `dartdoc_options.yaml`, `llms.txt`)
 
 ## [1.4.0] - 2026-08-21
 
@@ -266,7 +268,8 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.4.0...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.4.1...HEAD
+[1.4.1]: https://github.com/fluttersdk/wind/releases/tag/1.4.1
 [1.4.0]: https://github.com/fluttersdk/wind/releases/tag/1.4.0
 [1.3.0]: https://github.com/fluttersdk/wind/releases/tag/1.3.0
 [1.2.1]: https://github.com/fluttersdk/wind/releases/tag/1.2.1

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.4.0/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.4.1/%f%#L%l%'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.0+1
+version: 1.4.1+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.4.0 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.4.1 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.4.0
+version: 1.4.1
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -7,7 +7,7 @@ version: 2.12.2
 
 <!-- fluttersdk_wind 1.4.x | Skill v2.12.2 (2026-08-23) -->
 
-# Wind UI 1.3
+# Wind UI 1.4
 
 Utility-first Flutter styling. Every visual decision lives in a `className: String?` parsed at build time into an immutable `WindStyle` and composed into a native Flutter widget tree. Tailwind syntax (`flex`, `p-4`, `dark:bg-gray-800`, `hover:shadow-lg`), Flutter physics.
 


### PR DESCRIPTION
Patch release. Three fixes and a CI repair, no API surface change.

## What ships

| PR | Change |
|---|---|
| #180 | A multi-line `className` hid its flex tokens from the row and column composers, which this project's own style guide is what put there. |
| #181 | The registry dispatch could never fire: a `GITHUB_TOKEN`-created release raises no events, so 1.4.0 shipped a skill the registry only received by hand. `publish.yml` calls the workflow directly now. |
| #182 | Two controls claimed an action they did not have: a gestureless `WAnchor` announced itself as a button, and `WCheckbox` offered a tap for `onChanged: null`. |
| #184 | The other half of the checkbox case: a null `onChanged` now reads as disabled the way `WRadio` and `WSwitch` have always read it. |

## Two consumer-visible consequences

Both are in the release notes, neither is an API change:

- A `WCheckbox` with a null `onChanged` and `disabled:` classes now renders them, where before they never applied.
- A `WDynamic` JSON checkbox with no valid `onChange` now renders dimmed and announces itself as not enabled. It was already inert (the state write lives inside that same null callback), so what changed is that a silently non-functional control became a visibly disabled one.

Patch rather than minor: no public API moved, and the two consequences above only reach a caller who already had a non-functional control on screen.

## Release surfaces

`pubspec.yaml` 1.4.0 -> 1.4.1, `example/pubspec.yaml` -> `1.4.1+1`, the `dartdoc_options.yaml` source-link tag, the `llms.txt` version string, and `CHANGELOG.md` (`## [Unreleased]` promoted to `## [1.4.1] - 2026-08-23`, `[1.4.1]` link reference added, `[Unreleased]` redirected to `1.4.1...HEAD`).

The wind-ui skill needs no move for a patch: the nine reference H1s and the version marker already read `1.4`. One exception, fixed here and written up in the notes: **SKILL.md's own H1 has read `Wind UI 1.3` since the 1.4.0 release**, because the release checklist names three version spots in `skills/wind-ui/` and this is a fourth one nothing pointed at. It is the first line of the file an agent loads.

## Verification

- `flutter test`: 1710 passed, 1 pre-existing skip.
- `./tool/coverage.sh 90`: 94.8%.
- `dart analyze`: no issues (package and example). `dart format .`: no diff.
- `python3 tool/check-docs.py`: 72 doc pages, 0 issues.
- `dart pub publish --dry-run` on a clean tree: 0 warnings (the one hint is the gitignored local `pubspec_overrides.yaml`, which CI never sees).
- Release-notes extraction verified with the exact awk the `github-release` job runs: 23 non-empty lines for `1.4.1`.

## After merge

`git tag 1.4.1 && git push origin 1.4.1`. No `v` prefix; `publish.yml` matches `[0-9]+.[0-9]+.[0-9]+*`. That runs validate, the pub.dev publish over OIDC, the GitHub release, and then the registry dispatch, which #181 moved inside this pipeline. **1.4.1 is the first release to test that path**, so the `fluttersdk/ai` sync wants watching rather than assuming.