### PR TITLE
release: 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+---
+
+## [1.5.0] - 2026-08-25
+
 ### Changed
 
 - **`gap-*` on a flex container goes to `Flex.spacing` instead of injecting a `SizedBox` between every pair of children.** Spacing lands in the render object, so the gap costs no widget. Measured driving a real app, `SizedBox` was the most numerous wrapper in it at 1.06 per `WDiv` built and is now 0.23. The swap is deliberately NOT applied under `justify-around` or `justify-evenly`, which divide free space by the number of children: there the injected gaps are load-bearing, and handing them to `spacing` would move every real child (measured 138.7px apart against 118px on a three-child row). Those two keep the old path, and `gap_spacing_equivalence_test.dart` pins child DISTANCES under all six alignments, since a symmetry check passes under both mechanisms and would prove nothing. (`lib/src/widgets/w_div.dart`)
@@ -288,7 +292,8 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.4.1...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.5.0...HEAD
+[1.5.0]: https://github.com/fluttersdk/wind/releases/tag/1.5.0
 [1.4.1]: https://github.com/fluttersdk/wind/releases/tag/1.4.1
 [1.4.0]: https://github.com/fluttersdk/wind/releases/tag/1.4.0
 [1.3.0]: https://github.com/fluttersdk/wind/releases/tag/1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
----
-
 ## [1.5.0] - 2026-08-25
 
 ### Changed

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.4.1/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.5.0/%f%#L%l%'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.5.0"
   fluttersdk_wind_diagnostics_contracts:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.1+1
+version: 1.5.0+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.4.1 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.5.0 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.4.1
+version: 1.5.0
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -7,7 +7,7 @@ version: 2.13.0
 
 <!-- fluttersdk_wind 1.4.x | Skill v2.13.0 (2026-08-25) -->
 
-# Wind UI 1.4
+# Wind UI 1.5
 
 Utility-first Flutter styling. Every visual decision lives in a `className: String?` parsed at build time into an immutable `WindStyle` and composed into a native Flutter widget tree. Tailwind syntax (`flex`, `p-4`, `dark:bg-gray-800`, `hover:shadow-lg`), Flutter physics.
 

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wind-ui
-description: "fluttersdk_wind 1.4: utility-first Flutter styling with Tailwind-syntax className strings. 27 W-prefix widgets (WDiv, WText, WButton, WInput, WSelect, WDatePicker, WPopover, WCard, WTabs, plus five WForm* wrappers) parse className into a cached immutable WindStyle; WindRecipe and WindSlotRecipe compose variant classNames. Prefixes stack freely (dark: / hover: / focus: / md: / ios: / selected: / disabled: / custom), the last class in a family wins, an unrecognized token drops with a one-time kDebugMode hint, and every color token carries a dark: peer in the same className. TRIGGER when: writing or editing UI in a Flutter app that depends on fluttersdk_wind; any className string; any W-prefix widget; any WindTheme or WindThemeData reference; the user mentions Tailwind for Flutter, utility-first, className, or wind-ui. DO NOT TRIGGER when: backend, API, or state-management work that never touches a widget tree; a Flutter project without fluttersdk_wind in pubspec.yaml; Material-only widgets (Scaffold, AppBar, Dialog) with no Wind content inside."
+description: "fluttersdk_wind 1.5: utility-first Flutter styling with Tailwind-syntax className strings. 27 W-prefix widgets (WDiv, WText, WButton, WInput, WSelect, WDatePicker, WPopover, WCard, WTabs, plus five WForm* wrappers) parse className into a cached immutable WindStyle; WindRecipe and WindSlotRecipe compose variant classNames. Prefixes stack freely (dark: / hover: / focus: / md: / ios: / selected: / disabled: / custom), the last class in a family wins, an unrecognized token drops with a one-time kDebugMode hint, and every color token carries a dark: peer in the same className. TRIGGER when: writing or editing UI in a Flutter app that depends on fluttersdk_wind; any className string; any W-prefix widget; any WindTheme or WindThemeData reference; the user mentions Tailwind for Flutter, utility-first, className, or wind-ui. DO NOT TRIGGER when: backend, API, or state-management work that never touches a widget tree; a Flutter project without fluttersdk_wind in pubspec.yaml; Material-only widgets (Scaffold, AppBar, Dialog) with no Wind content inside."
 when_to_use: "Any task that produces, modifies, or audits Wind-styled UI: composing a className, picking the right W-widget, wiring a Form field, customizing WindThemeData, pairing dark-mode classes, debugging a layout or a RenderFlex overflow, building a popover, rendering a JSON tree via WDynamic, or composing a WindRecipe. Load it before the first line of new UI, and equally when auditing UI that already exists."
 version: 2.13.0
 ---
 
-<!-- fluttersdk_wind 1.4.x | Skill v2.13.0 (2026-08-25) -->
+<!-- fluttersdk_wind 1.5.x | Skill v2.13.0 (2026-08-25) -->
 
 # Wind UI 1.5
 

--- a/skills/wind-ui/references/debug.md
+++ b/skills/wind-ui/references/debug.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Debug bridge, parser cache, logger
+# Wind 1.5: Debug bridge, parser cache, logger
 
 Wiring `Wind.installDebugResolver()` and `Wind.installPerfResolver()` for E2E tooling (Dusk, Telescope, Playwright), understanding the parser cache (and why tests need `WindParser.clearCache()`), and reading `WindLogger` output for performance / composition debugging.
 

--- a/skills/wind-ui/references/design-culture.md
+++ b/skills/wind-ui/references/design-culture.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Design culture
+# Wind 1.5: Design culture
 
 Taste, expressed as className tokens. Every other reference file answers "does this token exist and what does it do"; this one answers "which token should this be". Reach for it when the task is a screen or a component with no design spec attached, when a layout renders correctly and still looks wrong, or when a reviewer says "it works but it feels off".
 

--- a/skills/wind-ui/references/dynamic.md
+++ b/skills/wind-ui/references/dynamic.md
@@ -1,4 +1,4 @@
-# Wind 1.4: WDynamic (server-driven UI)
+# Wind 1.5: WDynamic (server-driven UI)
 
 JSON node tree → Wind widget tree. Reach for this file when rendering UI from a CMS, A/B framework, remote-config service, or any source where the widget shape is decided at runtime.
 

--- a/skills/wind-ui/references/forms.md
+++ b/skills/wind-ui/references/forms.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Forms
+# Wind 1.5: Forms
 
 Building forms with validation. Use this file when picking between raw `W*` and `WForm*`, wiring `FormState.validate()`, handling async / server-side errors, or working around the WFormDatePicker range gotcha.
 

--- a/skills/wind-ui/references/layouts.md
+++ b/skills/wind-ui/references/layouts.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Layouts
+# Wind 1.5: Layouts
 
 12+ canonical layout recipes plus the Flutter constraint model that drives every overflow. Reach for this file when picking a layout pattern or recovering from RenderFlex / unbounded-height assertions.
 

--- a/skills/wind-ui/references/tailwind-divergence.md
+++ b/skills/wind-ui/references/tailwind-divergence.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Wind ≠ Tailwind divergence catalog
+# Wind 1.5: Wind ≠ Tailwind divergence catalog
 
 Comprehensive map of where Wind diverges from Tailwind CSS v3 and v4. Reach for this file when migrating a className from web, recovering from a "this token does not seem to do anything" stall, or auditing a Tailwind-trained codebase.
 

--- a/skills/wind-ui/references/theme.md
+++ b/skills/wind-ui/references/theme.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Theme, dark mode, responsive, platform
+# Wind 1.5: Theme, dark mode, responsive, platform
 
 Customizing `WindThemeData`, brightness control, breakpoint scale, platform prefixes. Reach for this file when adding custom colors, overriding the spacing scale, wiring a dark-mode toggle, defining a custom breakpoint, or recovering from the OverlayEntry context caveat.
 

--- a/skills/wind-ui/references/tokens.md
+++ b/skills/wind-ui/references/tokens.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Token catalog
+# Wind 1.5: Token catalog
 
 Exhaustive per-parser token reference. Reach for this file when verifying a className token exists, picking the right family, looking up an arbitrary-value pattern, or auditing className for unsupported syntax.
 

--- a/skills/wind-ui/references/widgets.md
+++ b/skills/wind-ui/references/widgets.md
@@ -1,4 +1,4 @@
-# Wind 1.4: Widget reference
+# Wind 1.5: Widget reference
 
 Full constructor surface, every named parameter, every default. Reach for this file when picking a widget, wiring callbacks, or recovering from a "what does this prop do?" stall.
 


### PR DESCRIPTION
Cuts 1.5.0.

Two changes since 1.4.1, both already reviewed and merged:

- **#188** `WindPerfCounters`: opt-in hit/miss/bypass counters on the parse path, published through the diagnostics contract. Off by default; a disabled counter is one static bool load.
- **#189** `WDiv` emits two fewer wrapper widgets per element: `gap-*` moves to `Flex.spacing` and `WindFlexOverflowScope` is published only when it changes the inherited answer. Measured at 12.1% fewer widget spans per `WDiv`, and on a scroll frame `RenderConstrainedBox` 865 -> 461 with every other render object unchanged.

This release is also what unblocks `magic_devtools#14`, whose CI cannot pass until `WindPerfCounters` and `Wind.installPerfResolver` exist on pub.dev.

Gate: `flutter test` 1743 passing (1 pre-existing skip), `dart analyze` clean, `dart format` clean. `flutter pub publish --dry-run` shows only the two expected notes: uncommitted files at dry-run time and the local `pubspec_overrides.yaml`, neither of which exists in CI.