### PR TITLE
fix(deps): one scope per commit message, not two

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,7 +72,9 @@ updates:
       - anilcancakir
     commit-message:
       prefix: chore(example-deps)
-      include: scope
+      # No `include: scope` here: Dependabot appends its own `(deps)` when that
+      # is set, and this prefix already carries a scope. The pair produced
+      # `chore(example-deps)(deps): ...` on the first bump.
     groups:
       example-minor-and-patch:
         patterns:


### PR DESCRIPTION
## What

Drops `include: scope` from the Dependabot buckets whose `prefix` already carries a scope.

## Why

`include: scope` appends Dependabot's own `(deps)`, so a prefix like `chore(backend-deps)` produces `chore(backend-deps)(deps): bump ...`. The first bump under the new config landed exactly that shape.

wind's config header warned about this ("'include: scope' appends '(deps)' automatically, keep prefix parens-free") and its own example bucket did it anyway, so the same fix applies there.

## Testing

Config parses; the affected buckets now carry a prefix and no `include`, the bare-prefix buckets keep it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update commit-message configuration to avoid redundant dependency labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->