### PR TITLE
chore(worktree): put worktrees under .claude and carry the overrides into them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ app.*.map.json
 
 # Local sibling-package path wiring (dev only)
 pubspec_overrides.yaml
+
+# Worktrees Claude Code creates for parallel sessions and isolated subagents.
+# Only this subdirectory: the rest of `.claude/` is tracked, because the rules
+# under it are part of the repository.
+.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,11 @@ pubspec_overrides.yaml
 
 # Worktrees Claude Code creates for parallel sessions and isolated subagents.
 # Only this subdirectory: the rest of `.claude/` is tracked, because the rules
-# under it are part of the repository.#
-# They sit inside the working tree rather than beside it, so `git clean -xdf` here
-# wipes a live worktree's contents while `.git/worktrees/<slug>` survives, leaving a
-# registration that needs `git worktree prune`. A worktree's `.git` is a file rather
-# than a directory, so git's nested-repo guard does not stop it.
+# under it are part of the repository.
+#
+# They sit inside the working tree rather than beside it. `git clean -xdf` leaves them
+# alone: git's nested-repository guard resolves a gitfile too, so it reports "Skipping
+# repository .claude/worktrees/<slug>" and the contents survive. `git clean -xdff` does
+# not skip them, and wipes a live worktree while `.git/worktrees/<slug>` survives,
+# leaving a registration that `git worktree prune` then has to clear.
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,9 @@ pubspec_overrides.yaml
 
 # Worktrees Claude Code creates for parallel sessions and isolated subagents.
 # Only this subdirectory: the rest of `.claude/` is tracked, because the rules
-# under it are part of the repository.
+# under it are part of the repository.#
+# They sit inside the working tree rather than beside it, so `git clean -xdf` here
+# wipes a live worktree's contents while `.git/worktrees/<slug>` survives, leaving a
+# registration that needs `git worktree prune`. A worktree's `.git` is a file rather
+# than a directory, so git's nested-repo guard does not stop it.
 .claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,21 @@
+# Gitignored files copied into every worktree Claude Code creates, for `--worktree`,
+# for `EnterWorktree`, and for a subagent with `isolation: worktree`.
+#
+# A worktree is a fresh checkout, so `pubspec_overrides.yaml` is absent from it, and
+# its absence fails silently rather than loudly: the siblings resolve from pub.dev
+# instead of the working trees beside this one, `flutter pub get` succeeds, and the
+# suite then passes against the PUBLISHED packages while the diff under review is of
+# the local ones. An unreleased sibling API is where that bites.
+#
+# `.gitignore` syntax, and only files that match AND are gitignored are copied, so a
+# tracked file can never be duplicated by this list.
+#
+# The paths inside `pubspec_overrides.yaml` have to be ABSOLUTE for this to work.
+# Worktrees live under `.claude/worktrees/<slug>`, so a relative `../magic` resolves
+# to `.claude/worktrees/magic`, which does not exist, and version solving fails on
+# the first path dependency.
+#
+# NOT processed when a WorktreeCreate hook replaces the default git logic; such a
+# hook has to copy these itself.
+
+pubspec_overrides.yaml


### PR DESCRIPTION
## What

- `.gitignore`: ignore `.claude/worktrees/` (only that subdirectory; the rules under `.claude/` stay tracked)
- `.worktreeinclude`: new, copies `pubspec_overrides.yaml` into every worktree Claude Code creates

## Why

Worktrees were opened beside the checkout as `<repo>-<slug>`, so they landed in the workspace directory next to the real repositories, and Claude Code's `EnterWorktree` could not be used at all: it writes to a fixed `.claude/worktrees/<slug>`.

Moving them inside exposes a problem the old layout hid. `pubspec_overrides.yaml` is gitignored, so a worktree never receives it, and the absence is silent rather than loud: the siblings resolve from pub.dev, `flutter pub get` succeeds, and the suite passes against the PUBLISHED packages while the diff under review is of the local ones. An unreleased sibling API is where that bites.

For the copy to be correct the local file needs ABSOLUTE paths, since a relative `../magic` resolves to `.claude/worktrees/magic` from inside a worktree. That file is machine-local and not committed, so this PR cannot carry it; the requirement is documented in `.worktreeinclude`.

## Testing

The pattern was proven end to end on fluttersdk/magic_starter#124 first: probe worktree opened under the new path, `pubspec_overrides.yaml` confirmed absent, copied in, `flutter pub get` resolved and `package_config.json` pointed at the local checkouts. Here I verified that every rewritten absolute path resolves to a real package directory and that `flutter pub get` still succeeds.

No Dart, YAML or `lib/` file is touched, so analyze, format and test have nothing to say about this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved isolated development workspace setup by preserving local package configuration across generated worktrees.
  * Added safeguards to keep temporary parallel-workspace files out of version control.
* **Documentation**
  * Clarified how workspace configuration is copied and how cleanup commands affect temporary worktrees, supporting more predictable development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->