### PR TITLE
release: 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 
 ---
 
-## [Unreleased]
+## [1.5.2] - 2026-09-08
 
 ### Fixed
 
@@ -315,7 +315,8 @@ Production deps: `flutter` (SDK), `flutter_svg ^2.0.0`, `fluttersdk_wind_diagnos
 
 The 1.0.0-alpha.1 through 1.0.0-alpha.10 release notes (Feb 2026 to May 2026) are preserved in git history and on the `v0` branch. The 0.0.x line is end-of-life; consumers pin to `^1.0.0` going forward.
 
-[Unreleased]: https://github.com/fluttersdk/wind/compare/1.5.1...HEAD
+[Unreleased]: https://github.com/fluttersdk/wind/compare/1.5.2...HEAD
+[1.5.2]: https://github.com/fluttersdk/wind/releases/tag/1.5.2
 [1.5.1]: https://github.com/fluttersdk/wind/releases/tag/1.5.1
 [1.5.0]: https://github.com/fluttersdk/wind/releases/tag/1.5.0
 [1.4.1]: https://github.com/fluttersdk/wind/releases/tag/1.4.1

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,3 +1,3 @@
 dartdoc:
   linkTo:
-    url: 'https://github.com/fluttersdk/wind/blob/1.5.1/%f%#L%l%'
+    url: 'https://github.com/fluttersdk/wind/blob/1.5.2/%f%#L%l%'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.1"
+    version: "1.5.2"
   fluttersdk_wind_diagnostics_contracts:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.5.1+1
+version: 1.5.2+1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # fluttersdk_wind
 
-> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.5.1 stable.
+> Tailwind CSS for Flutter. A utility-first styling framework that maps `className` strings to optimized Flutter widget trees, with 24-field `WindThemeData` theming, responsive prefixes (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`), `dark:`, state prefixes (`hover:` / `focus:` / `disabled:` / `loading:` / `selected:`), platform prefixes (`ios:` / `android:` / `web:` / `mobile:`), 27 W-prefix widgets, `WindRecipe` / `WindSlotRecipe` variant composition, server-driven UI via `WDynamic`, and three AI integration layers (hosted MCP server, Claude Code skill, and a skill distributed to 8+ AI clients via fluttersdk/ai). Open Source. Tailwind syntax. Flutter native. Version 1.5.2 stable.
 
 **Stack**: Flutter >=3.27.0 · Dart >=3.4.0 · Runtime deps: `flutter_svg`, `fluttersdk_wind_diagnostics_contracts`. No `mockito`, no state management library, no router.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluttersdk_wind
 description: Tailwind CSS for Flutter. Write className='flex p-4 bg-white dark:bg-gray-800' and Wind renders optimized widget trees with dark mode and responsive breakpoints.
-version: 1.5.1
+version: 1.5.2
 homepage: https://fluttersdk.com/wind
 repository: https://github.com/fluttersdk/wind
 issue_tracker: https://github.com/fluttersdk/wind/issues

--- a/skills/wind-ui/SKILL.md
+++ b/skills/wind-ui/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: "Any task that produces, modifies, or audits Wind-styled UI: compos
 version: 2.14.0
 ---
 
-<!-- fluttersdk_wind 1.5.x | Skill v2.13.2 (2026-09-07) -->
+<!-- fluttersdk_wind 1.5.x | Skill v2.14.0 (2026-09-08) -->
 
 # Wind UI 1.5
 


### PR DESCRIPTION
## What

Patch release. One change, `h-full`, and the two `max-*` discards it turned out to be hiding.

- **`h-full` resolves at the render layer (#200).** It went through a `LayoutBuilder`, which cannot answer an intrinsic query, so any `IntrinsicHeight` or `IntrinsicWidth` above it asserted `LayoutBuilder does not support returning intrinsic dimensions`. The limitation was written down on five surfaces with an escape hatch ("use explicit `h-*` instead") rather than fixed. It is the `WindFullHeightBox` render object now, which answers intrinsics by forwarding to its child, so it renders under an `IntrinsicHeight`, in a `Table` cell and in an `items-stretch` grid cell. `grid` is the last `LayoutBuilder` in the package.
- **`max-h-*` and `max-w-*` apply to an `h-full` element (#200).** Both were discarded by the same mechanism in two places: the cap arrived as a `ConstrainedBox` whose additional constraint `BoxConstraints.enforce` clamps into the incoming range, and the incoming range was already tight.

The render object also costs one object where the old path cost two, and drops the deferred layout pass with it. Measured in a consumer's broadcast grid at 5000 channels, one eight-scroll session: 840 `_RenderLayoutBuilder` and 840 `RenderFractionallySizedOverflowBox` become 1008 `_RenderFullHeight`, everything else moving within noise.

**Expect on upgrade,** two visible changes:

| case | before | after |
|:-----|-------:|------:|
| `h-full max-h-[120px]` under `ConstrainedBox(maxHeight: 400)` | 400 | 120 |
| `w-1/2 h-full max-w-[100px]` in a 300 pixel parent | 150 | 100 |
| `h-full` beside a 60 pixel sibling under an `IntrinsicHeight` | asserted | 60 |

A TIGHT parent still wins over `max-h-*`, which is the parent stating an exact size rather than the same bug.

## Version surfaces

The patch set, six files:

| File | Change |
|:-----|:-------|
| `pubspec.yaml` | `version: 1.5.2` |
| `example/pubspec.yaml` | `version: 1.5.2+1` |
| `dartdoc_options.yaml` | source-link tag `blob/1.5.2/` |
| `llms.txt` | `Version 1.5.2 stable` |
| `CHANGELOG.md` | `[Unreleased]` promoted to `[1.5.2] - 2026-09-08`, tag reference added, compare reference retargeted |
| `example/pubspec.lock` | the path-dep `version: "1.5.2"` entry, produced by `flutter pub get` inside `example/` |

`skills/wind-ui/` needs no version move for a patch: the nine reference H1s, SKILL.md's own H1, the `description` prefix and the `fluttersdk_wind 1.5.x` marker all still read right.

One thing did need fixing, in its own commit ahead of the bump: #200 moved SKILL.md's frontmatter to `version: 2.14.0` but left the line 8 marker at `Skill v2.13.2`, so the file stated two different versions of itself. The two have moved together on every skill change since 1.4.x.

## Testing

- `dart analyze`: clean
- `dart format --set-exit-if-changed .`: no diff, 390 files
- `flutter test`: 1782 passing, the one pre-existing skip
- `./tool/coverage.sh 90`: 95.2%
- `python3 tool/check-docs.py`: 0 issues across 72 doc pages
- `dart pub publish --dry-run`: 0 warnings on the committed tree, 1 hint (the gitignored `pubspec_overrides.yaml`, which CI does not have)
- Release-notes extraction (`awk` over the `## [1.5.2]` section, the check that fails the `github-release` job on empty notes): returns all four entries

## After merge

`git tag 1.5.2 && git push origin 1.5.2` triggers `publish.yml`: validate, pub.dev publish over OIDC, the GitHub Release, and the registry sync job that pushes `skills/wind-ui/` to `fluttersdk/ai`. pub.dev cannot unpublish, only retract, so the tag push is the point of no return.
